### PR TITLE
fix: Add npm install to dev-docker-compose.yaml and correct README and README.GSoC filename reference (Fix #14, also address #9)

### DIFF
--- a/README.GSoC.md
+++ b/README.GSoC.md
@@ -102,7 +102,7 @@ npm run dev
 #### Build and run with Docker Compose (recommended)
 From the project root:
 ```bash
-docker-compose -f docker-compose_dev.yml up -d
+docker-compose -f dev-docker-compose.yaml up -d
 ```
 - The UI will be available at [http://localhost:3000](http://localhost:3000)
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ npm install
 ### Start the development services:
 
 ```bash
-docker compose -f docker-compose_dev.yml up -d
+docker-compose -f dev-docker-compose.yaml up -d
 ```
 
 ### Stop the development services:
 
 ```bash
-docker compose -f docker-compose_dev.yml down
+docker-compose -f dev-docker-compose.yaml down
 ```
 
 ## 4. Access the Application

--- a/dev-docker-compose.yaml
+++ b/dev-docker-compose.yaml
@@ -12,10 +12,10 @@ services:
     environment:
       NEXT_PUBLIC_BASE_PATH: ${NEXT_APP_URL}
       NEXT_PUBLIC_API_URL: ${NEXT_API_URL}
-    command: npm run dev
+    command: sh -c "npm install && npm run dev"
     networks:
-     - istsos4_default
-     
+      - istsos4_default
+
 networks:
   istsos4_default:
     external: true


### PR DESCRIPTION
### Summary:
This PR fixes the #14 issue, addressing the same root cause reported in #9 which was carried over when `docker-compose_dev.yml` changed to `dev-docker-compose.yaml`.

### Changes:
- **`dev-docker-compose.yaml`**: Changed `command` from `npm run dev` to `sh -c "npm install && npm run dev"`. Make sure the dependencies got install within the Docker Container.

- **`README.GSoC.md`** and **`README.md`**: Updated the filename from `docker-compose_dev.yml` to `dev-docker-compose.yaml` to match the actual file.

### Related:
- Fixes the same issue as #9 