### PR TITLE
feat:Time-Travel History and Commit Explorer (Prototype)

### DIFF
--- a/ui/app/Home.tsx
+++ b/ui/app/Home.tsx
@@ -16,14 +16,16 @@
 import DatastreamTable from '@/features/datastreams/components/DatastreamTable'
 import FormModal from '@/features/forms/components/FormModal'
 import LeafletMap from '@/features/map/components/LeafletMap'
-import ChartModal from '@/features/observations/components/ChartModal'
+import ObservationGraph from '@/features/observations/components/ObservationGraph'
 import { getObservationsByDatastream } from '@/services/observations'
 import { Card } from '@heroui/card'
+import { Tab, Tabs } from '@heroui/tabs'
 import dayjs from 'dayjs'
-import { useEffect, useMemo, useRef, useState } from 'react'
-
+import React, { useMemo, useRef, useState } from 'react'
 import { useAuth } from '@/context/AuthContext'
+import Link from 'next/link'
 
+type BottomTabKey = 'table' | 'chart'
 type FormTabKey =
   | 'thing'
   | 'location'
@@ -39,37 +41,22 @@ type CreateFormState = {
 
 export default function Home({
   things,
-  locations,
-  sensors,
-  observedProperties,
-  datastreams,
-  networks,
   selectedNetwork,
 }: {
   things: any[]
-  locations: any[]
-  sensors: any[]
-  observedProperties: any[]
-  datastreams: any[]
-  networks: any[]
   selectedNetwork?: string
 }) {
   const { token } = useAuth()
   const [localThings, setLocalThings] = useState<any[]>(things)
 
-  useEffect(() => {
-    setLocalThings(things)
-  }, [things])
-
   const [selectedThingId, setSelectedThingId] = useState<string | null>(null)
+  const [activeBottomTab, setActiveBottomTab] = useState<BottomTabKey>('table')
   const [selectedDatastream, setSelectedDatastream] = useState<any | null>(null)
   const [createFormState, setCreateFormState] =
     useState<CreateFormState | null>(null)
 
   const [obsLoading, setObsLoading] = useState(false)
   const [obsError, setObsError] = useState<string | null>(null)
-  const [obsStart, setObsStart] = useState<string | null>(null)
-  const [obsEnd, setObsEnd] = useState<string | null>(null)
 
   const obsCacheRef = useRef<Map<string, any[]>>(new Map())
   const [observations, setObservations] = useState<any[]>([])
@@ -88,57 +75,44 @@ export default function Home({
   const closePanel = () => {
     setSelectedThingId(null)
     setSelectedDatastream(null)
+    setActiveBottomTab('table')
     setObservations([])
     setObsError(null)
     setObsLoading(false)
-    setObsStart(null)
-    setObsEnd(null)
   }
 
   const loadObservations = async (
     datastreamId: string,
-    phenomenonTime?: string,
-    range?: { start?: string | null; end?: string | null }
+    phenomenonTime?: string
   ) => {
     if (!token) {
       setObsError('Missing token')
       return
     }
 
-    let startIso = range?.start ?? null
-    let endIso = range?.end ?? null
-
-    if (!startIso || !endIso) {
-      const [, endRaw] = phenomenonTime?.split('/') ?? []
-
-      const end = endRaw ? dayjs.utc(endRaw) : dayjs.utc()
-      const start = end.subtract(7, 'day')
-      endIso = end.toISOString()
-      startIso = start.toISOString()
-    }
-
-    const cacheKey = `${datastreamId}|${startIso}|${endIso}`
-    const cached = obsCacheRef.current.get(cacheKey)
+    const cached = obsCacheRef.current.get(datastreamId)
     if (cached) {
       setObservations(cached)
-      setObsStart(startIso)
-      setObsEnd(endIso)
       return
     }
 
     setObsLoading(true)
     setObsError(null)
     try {
+      const [, endRaw] = phenomenonTime.split('/')
+
+      const end = dayjs.utc(endRaw)
+      const start = end.subtract(7, 'day')
+      const endIso = end.toISOString()
+      const startIso = start.toISOString()
       const { observationData } = await getObservationsByDatastream(
         token,
         datastreamId,
-        startIso ?? undefined,
-        endIso ?? undefined
+        startIso,
+        endIso
       )
-      obsCacheRef.current.set(cacheKey, observationData)
+      obsCacheRef.current.set(datastreamId, observationData)
       setObservations(observationData)
-      setObsStart(startIso)
-      setObsEnd(endIso)
     } catch (e: any) {
       setObsError(e?.message ?? 'Failed to load observations')
       setObservations([])
@@ -149,6 +123,7 @@ export default function Home({
 
   const openChartForDatastream = async (ds: any) => {
     setSelectedDatastream(ds)
+    setActiveBottomTab('chart')
 
     const dsId = String(ds?.['@iot.id'] ?? ds?.id ?? '')
     if (!dsId) {
@@ -159,23 +134,17 @@ export default function Home({
     await loadObservations(dsId, ds.phenomenonTime)
   }
 
-  const applyObservationRange = async (
-    start?: string | null,
-    end?: string | null
-  ) => {
-    const dsId = String(
-      selectedDatastream?.['@iot.id'] ?? selectedDatastream?.id ?? ''
-    )
-    if (!dsId) return
-
-    await loadObservations(dsId, selectedDatastream?.phenomenonTime, {
-      start,
-      end,
-    })
-  }
-
   return (
     <div className="relative h-[95vh] w-full overflow-hidden">
+      <div className="absolute top-[500px] right-6 z-[3000] flex gap-2">
+        <Link 
+          href="/history"
+          style={{ fontFamily: 'Arial, sans-serif' }}
+          className="flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-bold text-[#007668] shadow-lg transition-all hover:scale-105 hover:bg-[#007668] hover:text-white"
+        >
+          History Explorer
+        </Link>
+      </div>
       <LeafletMap
         things={localThings}
         selectedNetwork={selectedNetwork}
@@ -184,6 +153,7 @@ export default function Home({
           setSelectedDatastream(null)
           setObservations([])
           setObsError(null)
+          setActiveBottomTab('table')
         }}
         onCreateThingAt={(point) => {
           setCreateFormState({
@@ -199,58 +169,73 @@ export default function Home({
           latitude={createFormState.latitude}
           longitude={createFormState.longitude}
           initialTab={createFormState.initialTab}
-          existingEntities={{
-            things: localThings,
-            locations,
-            sensors,
-            observedProperties,
-            datastreams,
-            networks,
-          }}
+          things={localThings}
           isOpen={!!createFormState}
           onClose={() => {
             setCreateFormState(null)
           }}
         />
       ) : null}
-      <ChartModal
-        isOpen={!!selectedDatastream}
-        onClose={() => {
-          setSelectedDatastream(null)
-          setObservations([])
-          setObsError(null)
-          setObsLoading(false)
-          setObsStart(null)
-          setObsEnd(null)
-        }}
-        thing={selectedThing}
-        datastream={selectedDatastream}
-        observations={observations}
-        loading={obsLoading}
-        error={obsError}
-        start={obsStart}
-        end={obsEnd}
-        onApplyRange={applyObservationRange}
-        onResetRange={() => {
-          applyObservationRange(null, null)
-        }}
-      />
       {isPanelOpen && (
         <div className="fixed inset-x-0 bottom-0 z-[4000] pb-[env(safe-area-inset-bottom)]">
           <Card
-            className="max-h-[38vh] overflow-hidden rounded-none"
+            radius="none"
+            className="max-h-[38vh] overflow-hidden"
+            classNames={{ body: 'p-0' }}
           >
-            <div className="max-h-[32vh] overflow-auto pb-2">
-              <DatastreamTable
-                thing={selectedThing}
-                onClose={closePanel}
-                onCreateDatastream={() => {
-                  setCreateFormState({
-                    initialTab: 'datastream',
-                  })
+            <div className="px-3 pt-2">
+              <Tabs
+                selectedKey={activeBottomTab}
+                onSelectionChange={async (key) => {
+                  const next = key as BottomTabKey
+                  setActiveBottomTab(next)
+
+                  if (next === 'chart' && selectedDatastream) {
+                    const dsId = String(
+                      selectedDatastream?.['@iot.id'] ??
+                      selectedDatastream?.id ??
+                      ''
+                    )
+                    if (dsId)
+                      await loadObservations(
+                        dsId,
+                        selectedDatastream.phenomenonTime
+                      )
+                  }
                 }}
-                onOpenDetails={openChartForDatastream}
-              />
+                variant="underlined"
+                classNames={{
+                  cursor: 'bg-[#007668]',
+                  tab: 'data-[selected=true]:text-[#007668] font-bold',
+                }}
+              >
+                <Tab key="table" title="Table">
+                  <div className="max-h-[32vh] overflow-auto pb-2">
+                    <DatastreamTable
+                      thing={selectedThing}
+                      onClose={closePanel}
+                      onCreateDatastream={() => {
+                        setCreateFormState({
+                          initialTab: 'datastream',
+                        })
+                      }}
+                      onOpenDetails={openChartForDatastream}
+                    />
+                  </div>
+                </Tab>
+
+                <Tab key="chart" title="Chart">
+                  <div className="h-[32vh] p-3">
+                    <ObservationGraph
+                      thing={selectedThing}
+                      datastream={selectedDatastream}
+                      observations={observations}
+                      loading={obsLoading}
+                      error={obsError}
+                    />
+                  </div>
+                </Tab>
+              </Tabs>
             </div>
           </Card>
         </div>

--- a/ui/app/Home.tsx
+++ b/ui/app/Home.tsx
@@ -16,16 +16,15 @@
 import DatastreamTable from '@/features/datastreams/components/DatastreamTable'
 import FormModal from '@/features/forms/components/FormModal'
 import LeafletMap from '@/features/map/components/LeafletMap'
-import ObservationGraph from '@/features/observations/components/ObservationGraph'
+import ChartModal from '@/features/observations/components/ChartModal'
 import { getObservationsByDatastream } from '@/services/observations'
 import { Card } from '@heroui/card'
-import { Tab, Tabs } from '@heroui/tabs'
 import dayjs from 'dayjs'
-import React, { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
 import { useAuth } from '@/context/AuthContext'
 import Link from 'next/link'
 
-type BottomTabKey = 'table' | 'chart'
 type FormTabKey =
   | 'thing'
   | 'location'
@@ -41,22 +40,37 @@ type CreateFormState = {
 
 export default function Home({
   things,
+  locations,
+  sensors,
+  observedProperties,
+  datastreams,
+  networks,
   selectedNetwork,
 }: {
   things: any[]
+  locations: any[]
+  sensors: any[]
+  observedProperties: any[]
+  datastreams: any[]
+  networks: any[]
   selectedNetwork?: string
 }) {
   const { token } = useAuth()
   const [localThings, setLocalThings] = useState<any[]>(things)
 
+  useEffect(() => {
+    setLocalThings(things)
+  }, [things])
+
   const [selectedThingId, setSelectedThingId] = useState<string | null>(null)
-  const [activeBottomTab, setActiveBottomTab] = useState<BottomTabKey>('table')
   const [selectedDatastream, setSelectedDatastream] = useState<any | null>(null)
   const [createFormState, setCreateFormState] =
     useState<CreateFormState | null>(null)
 
   const [obsLoading, setObsLoading] = useState(false)
   const [obsError, setObsError] = useState<string | null>(null)
+  const [obsStart, setObsStart] = useState<string | null>(null)
+  const [obsEnd, setObsEnd] = useState<string | null>(null)
 
   const obsCacheRef = useRef<Map<string, any[]>>(new Map())
   const [observations, setObservations] = useState<any[]>([])
@@ -75,44 +89,57 @@ export default function Home({
   const closePanel = () => {
     setSelectedThingId(null)
     setSelectedDatastream(null)
-    setActiveBottomTab('table')
     setObservations([])
     setObsError(null)
     setObsLoading(false)
+    setObsStart(null)
+    setObsEnd(null)
   }
 
   const loadObservations = async (
     datastreamId: string,
-    phenomenonTime?: string
+    phenomenonTime?: string,
+    range?: { start?: string | null; end?: string | null }
   ) => {
     if (!token) {
       setObsError('Missing token')
       return
     }
 
-    const cached = obsCacheRef.current.get(datastreamId)
+    let startIso = range?.start ?? null
+    let endIso = range?.end ?? null
+
+    if (!startIso || !endIso) {
+      const [, endRaw] = phenomenonTime?.split('/') ?? []
+
+      const end = endRaw ? dayjs.utc(endRaw) : dayjs.utc()
+      const start = end.subtract(7, 'day')
+      endIso = end.toISOString()
+      startIso = start.toISOString()
+    }
+
+    const cacheKey = `${datastreamId}|${startIso}|${endIso}`
+    const cached = obsCacheRef.current.get(cacheKey)
     if (cached) {
       setObservations(cached)
+      setObsStart(startIso)
+      setObsEnd(endIso)
       return
     }
 
     setObsLoading(true)
     setObsError(null)
     try {
-      const [, endRaw] = phenomenonTime.split('/')
-
-      const end = dayjs.utc(endRaw)
-      const start = end.subtract(7, 'day')
-      const endIso = end.toISOString()
-      const startIso = start.toISOString()
       const { observationData } = await getObservationsByDatastream(
         token,
         datastreamId,
-        startIso,
-        endIso
+        startIso ?? undefined,
+        endIso ?? undefined
       )
-      obsCacheRef.current.set(datastreamId, observationData)
+      obsCacheRef.current.set(cacheKey, observationData)
       setObservations(observationData)
+      setObsStart(startIso)
+      setObsEnd(endIso)
     } catch (e: any) {
       setObsError(e?.message ?? 'Failed to load observations')
       setObservations([])
@@ -123,7 +150,6 @@ export default function Home({
 
   const openChartForDatastream = async (ds: any) => {
     setSelectedDatastream(ds)
-    setActiveBottomTab('chart')
 
     const dsId = String(ds?.['@iot.id'] ?? ds?.id ?? '')
     if (!dsId) {
@@ -134,10 +160,25 @@ export default function Home({
     await loadObservations(dsId, ds.phenomenonTime)
   }
 
+  const applyObservationRange = async (
+    start?: string | null,
+    end?: string | null
+  ) => {
+    const dsId = String(
+      selectedDatastream?.['@iot.id'] ?? selectedDatastream?.id ?? ''
+    )
+    if (!dsId) return
+
+    await loadObservations(dsId, selectedDatastream?.phenomenonTime, {
+      start,
+      end,
+    })
+  }
+
   return (
     <div className="relative h-[95vh] w-full overflow-hidden">
       <div className="absolute top-[500px] right-6 z-[3000] flex gap-2">
-        <Link 
+        <Link
           href="/history"
           style={{ fontFamily: 'Arial, sans-serif' }}
           className="flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-bold text-[#007668] shadow-lg transition-all hover:scale-105 hover:bg-[#007668] hover:text-white"
@@ -145,6 +186,7 @@ export default function Home({
           History Explorer
         </Link>
       </div>
+
       <LeafletMap
         things={localThings}
         selectedNetwork={selectedNetwork}
@@ -153,7 +195,6 @@ export default function Home({
           setSelectedDatastream(null)
           setObservations([])
           setObsError(null)
-          setActiveBottomTab('table')
         }}
         onCreateThingAt={(point) => {
           setCreateFormState({
@@ -169,73 +210,58 @@ export default function Home({
           latitude={createFormState.latitude}
           longitude={createFormState.longitude}
           initialTab={createFormState.initialTab}
-          things={localThings}
+          existingEntities={{
+            things: localThings,
+            locations,
+            sensors,
+            observedProperties,
+            datastreams,
+            networks,
+          }}
           isOpen={!!createFormState}
           onClose={() => {
             setCreateFormState(null)
           }}
         />
       ) : null}
+      <ChartModal
+        isOpen={!!selectedDatastream}
+        onClose={() => {
+          setSelectedDatastream(null)
+          setObservations([])
+          setObsError(null)
+          setObsLoading(false)
+          setObsStart(null)
+          setObsEnd(null)
+        }}
+        thing={selectedThing}
+        datastream={selectedDatastream}
+        observations={observations}
+        loading={obsLoading}
+        error={obsError}
+        start={obsStart}
+        end={obsEnd}
+        onApplyRange={applyObservationRange}
+        onResetRange={() => {
+          applyObservationRange(null, null)
+        }}
+      />
       {isPanelOpen && (
         <div className="fixed inset-x-0 bottom-0 z-[4000] pb-[env(safe-area-inset-bottom)]">
           <Card
-            radius="none"
-            className="max-h-[38vh] overflow-hidden"
-            classNames={{ body: 'p-0' }}
+            className="max-h-[38vh] overflow-hidden rounded-none"
           >
-            <div className="px-3 pt-2">
-              <Tabs
-                selectedKey={activeBottomTab}
-                onSelectionChange={async (key) => {
-                  const next = key as BottomTabKey
-                  setActiveBottomTab(next)
-
-                  if (next === 'chart' && selectedDatastream) {
-                    const dsId = String(
-                      selectedDatastream?.['@iot.id'] ??
-                      selectedDatastream?.id ??
-                      ''
-                    )
-                    if (dsId)
-                      await loadObservations(
-                        dsId,
-                        selectedDatastream.phenomenonTime
-                      )
-                  }
+            <div className="max-h-[32vh] overflow-auto pb-2">
+              <DatastreamTable
+                thing={selectedThing}
+                onClose={closePanel}
+                onCreateDatastream={() => {
+                  setCreateFormState({
+                    initialTab: 'datastream',
+                  })
                 }}
-                variant="underlined"
-                classNames={{
-                  cursor: 'bg-[#007668]',
-                  tab: 'data-[selected=true]:text-[#007668] font-bold',
-                }}
-              >
-                <Tab key="table" title="Table">
-                  <div className="max-h-[32vh] overflow-auto pb-2">
-                    <DatastreamTable
-                      thing={selectedThing}
-                      onClose={closePanel}
-                      onCreateDatastream={() => {
-                        setCreateFormState({
-                          initialTab: 'datastream',
-                        })
-                      }}
-                      onOpenDetails={openChartForDatastream}
-                    />
-                  </div>
-                </Tab>
-
-                <Tab key="chart" title="Chart">
-                  <div className="h-[32vh] p-3">
-                    <ObservationGraph
-                      thing={selectedThing}
-                      datastream={selectedDatastream}
-                      observations={observations}
-                      loading={obsLoading}
-                      error={obsError}
-                    />
-                  </div>
-                </Tab>
-              </Tabs>
+                onOpenDetails={openChartForDatastream}
+              />
             </div>
           </Card>
         </div>

--- a/ui/app/history/page.tsx
+++ b/ui/app/history/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import React from 'react'
+import TravelTimeUI from '@/features/history/components/TravelTimeUI'
+
+export default function HistoryPage() {
+  return <TravelTimeUI />
+}

--- a/ui/features/history/components/CommitHistoryTab.tsx
+++ b/ui/features/history/components/CommitHistoryTab.tsx
@@ -24,7 +24,7 @@ import {
   ENTITY_TYPES,
 } from '@/features/history/mock/historyMockData'
 
-// ─── Badge ────────────────────────────────────────────────────────────────────
+
 
 const BADGE: Record<ActionType, { bg: string; color: string }> = {
   INSERT: { bg: '#E6F9F1', color: '#0F6E56' },
@@ -44,14 +44,14 @@ function ActionBadge({ action }: { action: ActionType }) {
   )
 }
 
-// ─── Entity chip ──────────────────────────────────────────────────────────────
+
 
 const ENTITY_COLORS: Record<EntityType, string> = {
-  Things:             'bg-violet-100 text-violet-700',
-  Locations:          'bg-emerald-100 text-emerald-700',
-  Sensors:            'bg-orange-100 text-orange-700',
-  Datastreams:        'bg-sky-100 text-sky-700',
-  Observations:       'bg-pink-100 text-pink-700',
+  Things: 'bg-violet-100 text-violet-700',
+  Locations: 'bg-emerald-100 text-emerald-700',
+  Sensors: 'bg-orange-100 text-orange-700',
+  Datastreams: 'bg-sky-100 text-sky-700',
+  Observations: 'bg-pink-100 text-pink-700',
   ObservedProperties: 'bg-yellow-100 text-yellow-700',
   FeaturesOfInterest: 'bg-teal-100 text-teal-700',
   HistoricalLocations: 'bg-indigo-100 text-indigo-700',
@@ -65,7 +65,7 @@ function EntityChip({ entity }: { entity: EntityType }) {
   )
 }
 
-// ─── Modal ────────────────────────────────────────────────────────────────────
+
 
 function CommitModal({
   commit,
@@ -82,7 +82,7 @@ function CommitModal({
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
       <div className="w-full max-w-lg overflow-hidden rounded-2xl bg-white shadow-2xl" style={{ fontFamily: 'Arial, sans-serif' }}>
-        {/* Header */}
+
         <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50 px-6 py-4">
           <div className="flex flex-col gap-1">
             <div className="flex items-center gap-2">
@@ -103,7 +103,7 @@ function CommitModal({
         </div>
 
         <div className="max-h-[70vh] overflow-y-auto px-6 py-5 space-y-5">
-          {/* Commit details */}
+
           <div>
             <Label>Commit Details</Label>
             <div className="space-y-2 text-sm">
@@ -118,7 +118,6 @@ function CommitModal({
 
           <hr className="border-gray-100" />
 
-          {/* Diff */}
           <div>
             <Label>What Changed</Label>
             <div className="space-y-3">
@@ -142,7 +141,6 @@ function CommitModal({
 
           <hr className="border-gray-100" />
 
-          {/* Snapshot */}
           <div>
             <Label>Snapshot at this moment</Label>
             <div className="space-y-1.5">
@@ -177,7 +175,7 @@ function KV({ label, value }: { label: string; value: string }) {
   )
 }
 
-// ─── Stat badges ──────────────────────────────────────────────────────────────
+
 
 function StatPill({
   label,
@@ -196,7 +194,7 @@ function StatPill({
   )
 }
 
-// ─── Main Component ───────────────────────────────────────────────────────────
+
 
 /** Global cross-entity commit history feed */
 export default function CommitHistoryTab() {
@@ -219,7 +217,7 @@ export default function CommitHistoryTab() {
   return (
     <>
       <div className="rounded-xl border border-gray-200 bg-white shadow-sm" style={{ fontFamily: 'Arial, sans-serif' }}>
-        {/* Header */}
+
         <div className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-100 bg-gray-50 px-5 py-4">
           <div>
             <h2 className="text-sm font-semibold text-gray-800">Commit History</h2>
@@ -234,9 +232,9 @@ export default function CommitHistoryTab() {
           </div>
         </div>
 
-        {/* Filters */}
+
         <div className="flex flex-wrap items-center gap-3 border-b border-gray-100 px-5 py-3">
-          {/* Entity filter */}
+
           <div className="flex items-center gap-2">
             <span className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">Entity</span>
             <div className="flex flex-wrap gap-1">
@@ -244,11 +242,10 @@ export default function CommitHistoryTab() {
                 <button
                   key={e}
                   onClick={() => setEntityFilter(e)}
-                  className={`rounded-full px-2.5 py-0.5 text-[10px] font-semibold transition-colors ${
-                    entityFilter === e
-                      ? 'bg-[#007668] text-white'
-                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
-                  }`}
+                  className={`rounded-full px-2.5 py-0.5 text-[10px] font-semibold transition-colors ${entityFilter === e
+                    ? 'bg-[#007668] text-white'
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+                    }`}
                 >
                   {e}
                 </button>
@@ -256,7 +253,7 @@ export default function CommitHistoryTab() {
             </div>
           </div>
 
-          {/* Action filter */}
+
           <div className="ml-auto flex items-center gap-2">
             <span className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">Action</span>
             <div className="flex gap-1">
@@ -264,11 +261,10 @@ export default function CommitHistoryTab() {
                 <button
                   key={a}
                   onClick={() => setActionFilter(a)}
-                  className={`rounded-full px-2.5 py-0.5 text-[10px] font-semibold transition-colors ${
-                    actionFilter === a
-                      ? 'bg-[#007668] text-white'
-                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
-                  }`}
+                  className={`rounded-full px-2.5 py-0.5 text-[10px] font-semibold transition-colors ${actionFilter === a
+                    ? 'bg-[#007668] text-white'
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+                    }`}
                 >
                   {a}
                 </button>
@@ -277,7 +273,7 @@ export default function CommitHistoryTab() {
           </div>
         </div>
 
-        {/* Table */}
+
         {filtered.length === 0 ? (
           <div className="px-5 py-12 text-center text-sm text-gray-400">
             No commits match the current filters.
@@ -285,52 +281,51 @@ export default function CommitHistoryTab() {
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full min-w-max text-sm">
-            <thead>
-              <tr className="border-b border-gray-100 bg-gray-50 text-[10px] font-semibold uppercase tracking-widest text-gray-400">
-                <th className="px-4 py-3 text-left">Date</th>
-                <th className="px-4 py-3 text-left">Entity</th>
-                <th className="px-4 py-3 text-left">Author</th>
-                <th className="px-4 py-3 text-left">Action</th>
-                <th className="px-10 py-3 text-left">Properties</th>
-                <th className="px-4 py-3 text-left">Message</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map((row) => (
-                <tr
-                  key={`${row.entity}-${row.id}`}
-                  onClick={() => {
-                    setSelectedId(row.id)
-                    setModal({ commit: row, entity: row.entity })
-                  }}
-                  className={`cursor-pointer border-b border-gray-50 transition-colors last:border-0 ${
-                    selectedId === row.id ? 'bg-[#007668]/10' : 'hover:bg-gray-50'
-                  }`}
-                >
-                  <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-gray-500">
-                    {row.date}
-                  </td>
-                  <td className="px-4 py-3">
-                    <EntityChip entity={row.entity} />
-                  </td>
-                  <td className="px-4 py-3 text-gray-700">{row.author}</td>
-                  <td className="px-4 py-3">
-                    <ActionBadge action={row.action} />
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex flex-wrap gap-1">
-                      {Object.entries(row.snapshot.properties || {}).map(([pk, pv]) => (
-                        <span key={pk} className="bg-gray-100 text-[9px] px-1.5 py-0.5 rounded text-gray-500 border border-gray-200 uppercase font-bold tracking-tighter">
-                          {pk}: {String(pv)}
-                        </span>
-                      ))}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 italic text-gray-600">"{row.message}"</td>
+              <thead>
+                <tr className="border-b border-gray-100 bg-gray-50 text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+                  <th className="px-4 py-3 text-left">Date</th>
+                  <th className="px-4 py-3 text-left">Entity</th>
+                  <th className="px-4 py-3 text-left">Author</th>
+                  <th className="px-4 py-3 text-left">Action</th>
+                  <th className="px-10 py-3 text-left">Properties</th>
+                  <th className="px-4 py-3 text-left">Message</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {filtered.map((row) => (
+                  <tr
+                    key={`${row.entity}-${row.id}`}
+                    onClick={() => {
+                      setSelectedId(row.id)
+                      setModal({ commit: row, entity: row.entity })
+                    }}
+                    className={`cursor-pointer border-b border-gray-50 transition-colors last:border-0 ${selectedId === row.id ? 'bg-[#007668]/10' : 'hover:bg-gray-50'
+                      }`}
+                  >
+                    <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-gray-500">
+                      {row.date}
+                    </td>
+                    <td className="px-4 py-3">
+                      <EntityChip entity={row.entity} />
+                    </td>
+                    <td className="px-4 py-3 text-gray-700">{row.author}</td>
+                    <td className="px-4 py-3">
+                      <ActionBadge action={row.action} />
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        {Object.entries(row.snapshot.properties || {}).map(([pk, pv]) => (
+                          <span key={pk} className="bg-gray-100 text-[9px] px-1.5 py-0.5 rounded text-gray-500 border border-gray-200 uppercase font-bold tracking-tighter">
+                            {pk}: {String(pv)}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 italic text-gray-600">"{row.message}"</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         )}
       </div>

--- a/ui/features/history/components/CommitHistoryTab.tsx
+++ b/ui/features/history/components/CommitHistoryTab.tsx
@@ -1,0 +1,348 @@
+'use client'
+
+// Copyright 2026 SUPSI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useState } from 'react'
+
+import {
+  type ActionType,
+  type CommitRow,
+  type EntityType,
+  ALL_COMMITS_GLOBAL,
+  ENTITY_TYPES,
+} from '@/features/history/mock/historyMockData'
+
+// ─── Badge ────────────────────────────────────────────────────────────────────
+
+const BADGE: Record<ActionType, { bg: string; color: string }> = {
+  INSERT: { bg: '#E6F9F1', color: '#0F6E56' },
+  UPDATE: { bg: '#E6F1FB', color: '#185FA5' },
+  DELETE: { bg: '#FCEBEB', color: '#A32D2D' },
+}
+
+function ActionBadge({ action }: { action: ActionType }) {
+  const { bg, color } = BADGE[action]
+  return (
+    <span
+      className="inline-flex items-center rounded px-2 py-0.5 text-xs font-semibold tracking-wide"
+      style={{ background: bg, color }}
+    >
+      {action}
+    </span>
+  )
+}
+
+// ─── Entity chip ──────────────────────────────────────────────────────────────
+
+const ENTITY_COLORS: Record<EntityType, string> = {
+  Things:             'bg-violet-100 text-violet-700',
+  Locations:          'bg-emerald-100 text-emerald-700',
+  Sensors:            'bg-orange-100 text-orange-700',
+  Datastreams:        'bg-sky-100 text-sky-700',
+  Observations:       'bg-pink-100 text-pink-700',
+  ObservedProperties: 'bg-yellow-100 text-yellow-700',
+  FeaturesOfInterest: 'bg-teal-100 text-teal-700',
+  HistoricalLocations: 'bg-indigo-100 text-indigo-700',
+}
+
+function EntityChip({ entity }: { entity: EntityType }) {
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${ENTITY_COLORS[entity]}`}>
+      {entity}
+    </span>
+  )
+}
+
+// ─── Modal ────────────────────────────────────────────────────────────────────
+
+function CommitModal({
+  commit,
+  entity,
+  onClose,
+}: {
+  commit: CommitRow
+  entity: EntityType
+  onClose: () => void
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="w-full max-w-lg overflow-hidden rounded-2xl bg-white shadow-2xl" style={{ fontFamily: 'Arial, sans-serif' }}>
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50 px-6 py-4">
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <p className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+                Version Detail
+              </p>
+              <EntityChip entity={entity} />
+            </div>
+            <p className="font-mono text-sm font-semibold text-gray-800">{commit.date}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="flex h-8 items-center justify-center rounded px-3 text-[10px] font-bold uppercase tracking-wider text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700"
+            aria-label="Close"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="max-h-[70vh] overflow-y-auto px-6 py-5 space-y-5">
+          {/* Commit details */}
+          <div>
+            <Label>Commit Details</Label>
+            <div className="space-y-2 text-sm">
+              <KV label="Author" value={commit.author} />
+              <div className="flex items-center gap-3">
+                <span className="w-28 shrink-0 text-xs text-gray-400">Action</span>
+                <ActionBadge action={commit.action} />
+              </div>
+              <KV label="Message" value={`"${commit.message}"`} />
+            </div>
+          </div>
+
+          <hr className="border-gray-100" />
+
+          {/* Diff */}
+          <div>
+            <Label>What Changed</Label>
+            <div className="space-y-3">
+              {commit.diff.map((d, i) => (
+                <div key={i}>
+                  <p className="mb-1 text-xs font-medium text-gray-600">{d.field}</p>
+                  <div className="overflow-hidden rounded-md border border-gray-100 font-mono text-xs">
+                    <div className="flex gap-2 bg-red-50 px-3 py-1.5 text-red-700">
+                      <span className="select-none font-bold">−</span>
+                      <span>{d.previous}</span>
+                    </div>
+                    <div className="flex gap-2 bg-green-50 px-3 py-1.5 text-green-700">
+                      <span className="select-none font-bold">+</span>
+                      <span>{d.next}</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <hr className="border-gray-100" />
+
+          {/* Snapshot */}
+          <div>
+            <Label>Snapshot at this moment</Label>
+            <div className="space-y-1.5">
+              {Object.entries(commit.snapshot).map(([k, v]) => (
+                <div key={k} className="flex items-start gap-3 text-sm">
+                  <span className="w-40 shrink-0 text-xs text-gray-400">{k}</span>
+                  <span className="font-medium text-[#007668]">{v}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Label({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-3 text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+      {children}
+    </p>
+  )
+}
+
+function KV({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="w-28 shrink-0 text-xs text-gray-400">{label}</span>
+      <span className="text-gray-800">{value}</span>
+    </div>
+  )
+}
+
+// ─── Stat badges ──────────────────────────────────────────────────────────────
+
+function StatPill({
+  label,
+  count,
+  color,
+}: {
+  label: string
+  count: number
+  color: string
+}) {
+  return (
+    <div className={`flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold ${color}`}>
+      <span className="tabular-nums">{count}</span>
+      <span>{label}</span>
+    </div>
+  )
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+/** Global cross-entity commit history feed */
+export default function CommitHistoryTab() {
+  const [entityFilter, setEntityFilter] = useState<EntityType | 'All'>('All')
+  const [actionFilter, setActionFilter] = useState<ActionType | 'All'>('All')
+  const [modal, setModal] = useState<{ commit: CommitRow; entity: EntityType } | null>(null)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  const filtered = ALL_COMMITS_GLOBAL.filter((c) => {
+    if (entityFilter !== 'All' && c.entity !== entityFilter) return false
+    if (actionFilter !== 'All' && c.action !== actionFilter) return false
+    return true
+  })
+
+  // Summary counts
+  const insertCount = ALL_COMMITS_GLOBAL.filter((c) => c.action === 'INSERT').length
+  const updateCount = ALL_COMMITS_GLOBAL.filter((c) => c.action === 'UPDATE').length
+  const deleteCount = ALL_COMMITS_GLOBAL.filter((c) => c.action === 'DELETE').length
+
+  return (
+    <>
+      <div className="rounded-xl border border-gray-200 bg-white shadow-sm" style={{ fontFamily: 'Arial, sans-serif' }}>
+        {/* Header */}
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-100 bg-gray-50 px-5 py-4">
+          <div>
+            <h2 className="text-sm font-semibold text-gray-800">Commit History</h2>
+            <p className="mt-0.5 text-xs text-gray-400">
+              {ALL_COMMITS_GLOBAL.length} commits across all entities — showing {filtered.length}
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <StatPill label="INSERT" count={insertCount} color="bg-[#E6F9F1] text-[#0F6E56]" />
+            <StatPill label="UPDATE" count={updateCount} color="bg-[#E6F1FB] text-[#185FA5]" />
+            <StatPill label="DELETE" count={deleteCount} color="bg-[#FCEBEB] text-[#A32D2D]" />
+          </div>
+        </div>
+
+        {/* Filters */}
+        <div className="flex flex-wrap items-center gap-3 border-b border-gray-100 px-5 py-3">
+          {/* Entity filter */}
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">Entity</span>
+            <div className="flex flex-wrap gap-1">
+              {(['All', ...ENTITY_TYPES] as const).map((e) => (
+                <button
+                  key={e}
+                  onClick={() => setEntityFilter(e)}
+                  className={`rounded-full px-2.5 py-0.5 text-[10px] font-semibold transition-colors ${
+                    entityFilter === e
+                      ? 'bg-[#007668] text-white'
+                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+                  }`}
+                >
+                  {e}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Action filter */}
+          <div className="ml-auto flex items-center gap-2">
+            <span className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">Action</span>
+            <div className="flex gap-1">
+              {(['All', 'INSERT', 'UPDATE', 'DELETE'] as const).map((a) => (
+                <button
+                  key={a}
+                  onClick={() => setActionFilter(a)}
+                  className={`rounded-full px-2.5 py-0.5 text-[10px] font-semibold transition-colors ${
+                    actionFilter === a
+                      ? 'bg-[#007668] text-white'
+                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+                  }`}
+                >
+                  {a}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Table */}
+        {filtered.length === 0 ? (
+          <div className="px-5 py-12 text-center text-sm text-gray-400">
+            No commits match the current filters.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-max text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 bg-gray-50 text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+                <th className="px-4 py-3 text-left">Date</th>
+                <th className="px-4 py-3 text-left">Entity</th>
+                <th className="px-4 py-3 text-left">Author</th>
+                <th className="px-4 py-3 text-left">Action</th>
+                <th className="px-10 py-3 text-left">Properties</th>
+                <th className="px-4 py-3 text-left">Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((row) => (
+                <tr
+                  key={`${row.entity}-${row.id}`}
+                  onClick={() => {
+                    setSelectedId(row.id)
+                    setModal({ commit: row, entity: row.entity })
+                  }}
+                  className={`cursor-pointer border-b border-gray-50 transition-colors last:border-0 ${
+                    selectedId === row.id ? 'bg-[#007668]/10' : 'hover:bg-gray-50'
+                  }`}
+                >
+                  <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-gray-500">
+                    {row.date}
+                  </td>
+                  <td className="px-4 py-3">
+                    <EntityChip entity={row.entity} />
+                  </td>
+                  <td className="px-4 py-3 text-gray-700">{row.author}</td>
+                  <td className="px-4 py-3">
+                    <ActionBadge action={row.action} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {Object.entries(row.snapshot.properties || {}).map(([pk, pv]) => (
+                        <span key={pk} className="bg-gray-100 text-[9px] px-1.5 py-0.5 rounded text-gray-500 border border-gray-200 uppercase font-bold tracking-tighter">
+                          {pk}: {String(pv)}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 italic text-gray-600">"{row.message}"</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          </div>
+        )}
+      </div>
+
+      {modal && (
+        <CommitModal
+          commit={modal.commit}
+          entity={modal.entity}
+          onClose={() => setModal(null)}
+        />
+      )}
+    </>
+  )
+}
+

--- a/ui/features/history/components/CommitModal.tsx
+++ b/ui/features/history/components/CommitModal.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { CommitRow } from './travelTimeTypes'
+import { ActionBadge, SectionLabel, KV } from './TravelTimeShared'
+
+export function CommitModal({ commit, onClose }: { commit: CommitRow; onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="w-full max-w-lg overflow-hidden rounded-2xl bg-white shadow-2xl" style={{ fontFamily: 'Arial, sans-serif' }}>
+        <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50 px-6 py-4">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">Version Detail</p>
+            <p className="mt-0.5 font-mono text-sm font-semibold text-gray-800">{commit.date}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="flex h-8 items-center justify-center rounded px-3 text-[10px] font-bold uppercase tracking-wider text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700"
+            aria-label="Close"
+          >
+            Close
+          </button>
+        </div>
+        <div className="max-h-[70vh] space-y-5 overflow-y-auto px-6 py-5">
+          <div>
+            <SectionLabel>Commit Details</SectionLabel>
+            <div className="space-y-2 text-sm">
+              <KV label="Author" value={commit.author} />
+              <div className="flex items-center gap-3">
+                <span className="w-28 shrink-0 text-xs text-gray-400">Action</span>
+                <ActionBadge action={commit.action} />
+              </div>
+              <KV label="Message" value={`"${commit.message}"`} />
+            </div>
+          </div>
+          <hr className="border-gray-100" />
+          <div>
+            <SectionLabel>What Changed</SectionLabel>
+            <div className="space-y-3">
+              {commit.diff.map((d, i) => (
+                <div key={i}>
+                  <p className="mb-1 text-xs font-medium text-gray-600">{d.field}</p>
+                  <div className="overflow-hidden rounded-md border border-gray-100 font-mono text-xs">
+                    <div className="flex gap-2 bg-red-50 px-3 py-1.5 text-red-700 font-bold">
+                      <span className="select-none">−</span>
+                      <span>{d.previous}</span>
+                    </div>
+                    <div className="flex gap-2 bg-green-50 px-3 py-1.5 text-green-700 font-bold">
+                      <span className="select-none">+</span>
+                      <span>{d.next}</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+          <hr className="border-gray-100" />
+          <div>
+            <SectionLabel>Snapshot at this moment</SectionLabel>
+            <div className="space-y-1.5">
+              {Object.entries(commit.snapshot).map(([k, v]) => (
+                <div key={k} className="flex flex-col gap-1 border-b border-gray-50 pb-2 last:border-0 last:pb-0">
+                  <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">{k}</span>
+                  {k === 'properties' ? (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {Object.entries(v || {}).map(([pk, pv]) => (
+                        <span key={pk} className="bg-[#007668]/5 text-[#007668] text-[10px] px-2 py-0.5 rounded border border-[#007668]/20 font-bold">
+                          {pk}: {String(pv)}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="text-sm font-bold text-gray-700">{String(v)}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/features/history/components/EntityDetailScreen.tsx
+++ b/ui/features/history/components/EntityDetailScreen.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react'
+import { EntityType, GenericEntity, EntityTab } from './travelTimeTypes'
+import { SectionLabel } from './TravelTimeShared'
+import { HistorySubTab } from './HistorySubTab'
+
+export function EntityDetailScreen({
+  entityType,
+  entity,
+  onBack,
+}: {
+  entityType: EntityType
+  entity: GenericEntity
+  onBack: () => void
+}) {
+  const [tab, setTab] = useState<EntityTab>('History')
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6" style={{ fontFamily: 'Arial, sans-serif' }}>
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-5 flex items-center gap-4">
+          <button
+            onClick={onBack}
+            className="flex h-8 items-center justify-center rounded-lg border bg-white px-3 text-[10px] font-bold uppercase tracking-wider text-gray-400 shadow-sm transition-colors hover:border-[#007668] hover:text-[#007668]"
+          >
+            Back
+          </button>
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+              {entityType.replace(/s$/, '')} #{entity.id}
+            </p>
+            <h1 className="text-lg font-bold text-gray-800">{entity.name || entity.result || 'Unnamed Entity'}</h1>
+          </div>
+        </div>
+        <div className="mb-4 flex gap-1 rounded-xl border bg-white p-1 shadow-sm">
+          {(['Details', 'History'] as EntityTab[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`rounded-lg px-4 py-1.5 text-sm font-bold transition-all ${
+                tab === t ? 'bg-[#007668] text-white shadow-sm' : 'text-gray-400 hover:text-gray-600'
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        {tab === 'Details' && (
+          <div className="space-y-4 rounded-xl border bg-white p-5 shadow-sm">
+            <div className="grid grid-cols-2 gap-x-8 gap-y-4">
+              {Object.entries(entity).map(([k, v]) => {
+                if (k === 'properties') return null
+                return (
+                  <div key={k} className="flex flex-col border-b border-gray-50 pb-2">
+                    <span className="text-[10px] font-bold uppercase tracking-tight text-gray-400">{k}</span>
+                    <span className="text-sm font-semibold text-gray-700">{String(v)}</span>
+                  </div>
+                )
+              })}
+            </div>
+            {entity.properties && Object.keys(entity.properties).length > 0 && (
+              <div className="mt-6 border-t border-gray-100 pt-4">
+                <SectionLabel>Metadata Properties</SectionLabel>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {Object.entries(entity.properties).map(([pk, pv]) => (
+                    <div key={pk} className="flex items-center gap-2 rounded-lg border border-[#007668]/20 bg-[#007668]/5 px-3 py-1.5">
+                      <span className="text-[10px] font-bold uppercase text-[#007668] opacity-70">{pk}:</span>
+                      <span className="text-xs font-bold text-[#007668]">{String(pv)}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+        {tab === 'History' && <HistorySubTab entityType={entityType} />}
+      </div>
+    </div>
+  )
+}

--- a/ui/features/history/components/HistorySubTab.tsx
+++ b/ui/features/history/components/HistorySubTab.tsx
@@ -12,7 +12,7 @@ export function HistorySubTab({ entityType }: { entityType: EntityType }) {
 
   const rawCommits = MOCK_COMMITS[entityType] || []
   
-  // Simple mock filtering based on period
+
   const entityCommits = rawCommits.filter((c, i) => {
     if (period === 'Day') return i === 0 // Just the most recent for "Day" mock
     if (period === 'Week') return i < 2   // First two for "Week"

--- a/ui/features/history/components/HistorySubTab.tsx
+++ b/ui/features/history/components/HistorySubTab.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react'
+import { EntityType, Period, CommitRow } from './travelTimeTypes'
+import { MOCK_COMMITS, PERIOD_BARS } from './travelTimeMockData'
+import { ActionBadge } from './TravelTimeShared'
+import { CommitModal } from './CommitModal'
+
+export function HistorySubTab({ entityType }: { entityType: EntityType }) {
+  const [period, setPeriod] = useState<Period>('Month')
+  const [modal, setModal] = useState<CommitRow | null>(null)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [hoverBar, setHoverBar] = useState<{ label: string; count: number } | null>(null)
+
+  const rawCommits = MOCK_COMMITS[entityType] || []
+  
+  // Simple mock filtering based on period
+  const entityCommits = rawCommits.filter((c, i) => {
+    if (period === 'Day') return i === 0 // Just the most recent for "Day" mock
+    if (period === 'Week') return i < 2   // First two for "Week"
+    return true                          // All for "Month"
+  })
+
+  const bars = PERIOD_BARS[period]
+
+  return (
+    <div className="space-y-4" style={{ fontFamily: 'Arial, sans-serif' }}>
+      <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-bold text-gray-800 tracking-tight">Activity Graph</h3>
+            <p className="text-[10px] text-gray-400 uppercase tracking-widest font-bold">Commit Frequency — {period}</p>
+          </div>
+          <div className="flex overflow-hidden rounded-xl border border-gray-100 bg-gray-50 p-0.5 shadow-inner">
+            {(['Day', 'Week', 'Month'] as Period[]).map((p) => (
+              <button
+                key={p}
+                onClick={() => {
+                   setPeriod(p)
+                   setSelectedId(null)
+                }}
+                className={`px-4 py-1.5 text-[10px] font-bold uppercase tracking-wider rounded-lg transition-all ${
+                  period === p ? 'bg-[#007668] text-white shadow-sm' : 'text-gray-400 hover:text-gray-600'
+                }`}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+        </div>
+        
+        <div className="relative pt-6">
+          {hoverBar && (
+            <div className="absolute top-0 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-2 py-1 rounded text-[9px] font-bold z-10 animate-in fade-in zoom-in duration-200">
+               {hoverBar.label}: {hoverBar.count} mutations
+            </div>
+          )}
+          <div className="flex items-end gap-1" style={{ height: 60 }}>
+            {bars.map((bar, i) => (
+              <div
+                key={i}
+                onMouseEnter={() => setHoverBar(bar)}
+                onMouseLeave={() => setHoverBar(null)}
+                className={`flex-1 rounded-t-md transition-all duration-300 cursor-pointer ${
+                  bar.count === 0 ? 'bg-gray-100 hover:bg-gray-200' : 'bg-[#007668] hover:bg-[#007668]/80'
+                }`}
+                style={{ height: `${Math.max(10, (bar.count / 5) * 100)}%` }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="border-b border-gray-100 bg-gray-50/30 px-5 py-4">
+          <h3 className="text-sm font-bold text-gray-800 tracking-tight">Timeline: {period}</h3>
+          <p className="text-[10px] text-gray-400 uppercase tracking-widest font-bold">Chronological audit log</p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b bg-gray-50/50 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                <th className="px-5 py-4">Timestamp</th>
+                <th className="px-5 py-4">Author</th>
+                <th className="px-5 py-4">Action</th>
+                <th className="px-5 py-4">Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entityCommits.length > 0 ? entityCommits.map((c) => (
+                <tr
+                  key={c.id}
+                  onClick={() => {
+                    setSelectedId(c.id)
+                    setModal(c)
+                  }}
+                  className={`cursor-pointer border-b last:border-0 hover:bg-[#007668]/5 transition-colors ${
+                    selectedId === c.id ? 'bg-[#007668]/10' : ''
+                  }`}
+                >
+                  <td className="px-5 py-4 font-mono text-xs text-gray-500">{c.date}</td>
+                  <td className="px-5 py-4 font-bold text-gray-700">{c.author}</td>
+                  <td className="px-5 py-4">
+                    <ActionBadge action={c.action} />
+                  </td>
+                  <td className="px-5 py-4 italic text-gray-600 font-medium">"{c.message}"</td>
+                </tr>
+              )) : (
+                <tr>
+                  <td colSpan={4} className="px-5 py-10 text-center text-gray-400 italic text-xs">No records found for this period.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      {modal && <CommitModal commit={modal} onClose={() => setModal(null)} />}
+    </div>
+  )
+}

--- a/ui/features/history/components/HistoryTab.tsx
+++ b/ui/features/history/components/HistoryTab.tsx
@@ -25,7 +25,7 @@ import {
   HISTORY_MOCK,
 } from '@/features/history/mock/historyMockData'
 
-// ─── Badge ───────────────────────────────────────────────────────────────────
+
 
 const BADGE: Record<ActionType, { bg: string; color: string }> = {
   INSERT: { bg: '#E6F9F1', color: '#0F6E56' },
@@ -45,7 +45,7 @@ function ActionBadge({ action }: { action: ActionType }) {
   )
 }
 
-// ─── Shared Modal ─────────────────────────────────────────────────────────────
+
 
 function CommitModal({
   commit,
@@ -62,7 +62,7 @@ function CommitModal({
       }}
     >
       <div className="w-full max-w-lg overflow-hidden rounded-2xl bg-white shadow-2xl" style={{ fontFamily: 'Arial, sans-serif' }}>
-        {/* Header */}
+
         <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50 px-6 py-4">
           <div>
             <p className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">
@@ -82,7 +82,7 @@ function CommitModal({
         </div>
 
         <div className="max-h-[70vh] overflow-y-auto px-6 py-5 space-y-5">
-          {/* Commit details */}
+
           <div>
             <SectionLabel>Commit Details</SectionLabel>
             <div className="space-y-2 text-sm">
@@ -97,7 +97,7 @@ function CommitModal({
 
           <hr className="border-gray-100" />
 
-          {/* Diff */}
+
           <div>
             <SectionLabel>What Changed</SectionLabel>
             <div className="space-y-3">
@@ -121,7 +121,7 @@ function CommitModal({
 
           <hr className="border-gray-100" />
 
-          {/* Snapshot */}
+
           <div>
             <SectionLabel>Snapshot at this moment</SectionLabel>
             <div className="space-y-1.5">
@@ -139,7 +139,7 @@ function CommitModal({
   )
 }
 
-// ─── Entity State Card ────────────────────────────────────────────────────────
+
 
 function EntityCard({
   entity,
@@ -193,7 +193,7 @@ function EntityCard({
   )
 }
 
-// ─── Commit List Table ────────────────────────────────────────────────────────
+
 
 function CommitTable({
   rows,
@@ -240,7 +240,7 @@ function CommitTable({
   )
 }
 
-// ─── Date + Time inputs ───────────────────────────────────────────────────────
+
 
 function DateTimeInput({
   label,
@@ -289,7 +289,7 @@ function SearchButton({ onClick }: { onClick: () => void }) {
   )
 }
 
-// ─── Tiny shared helpers ──────────────────────────────────────────────────────
+
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -308,7 +308,7 @@ function KV({ label, value }: { label: string; value: string }) {
   )
 }
 
-// ─── Main Component ───────────────────────────────────────────────────────────
+
 
 type QueryMode = 'single' | 'range'
 
@@ -354,7 +354,7 @@ export default function HistoryTab({ entityType }: HistoryTabProps) {
   return (
     <>
       <div className="rounded-xl border border-gray-200 bg-white shadow-sm" style={{ fontFamily: 'Arial, sans-serif' }}>
-        {/* Mode toggle */}
+
         <div className="flex border-b border-gray-100">
           {MODES.map(({ key, label }) => (
             <button
@@ -372,7 +372,7 @@ export default function HistoryTab({ entityType }: HistoryTabProps) {
           ))}
         </div>
 
-        {/* ── Single Point ── */}
+
         {mode === 'single' && (
           <div className="p-5">
             <SectionLabel>as_of</SectionLabel>
@@ -399,7 +399,7 @@ export default function HistoryTab({ entityType }: HistoryTabProps) {
           </div>
         )}
 
-        {/* ── Range ── */}
+
         {mode === 'range' && (
           <div className="p-5">
             <SectionLabel>from_to</SectionLabel>
@@ -433,7 +433,7 @@ export default function HistoryTab({ entityType }: HistoryTabProps) {
         )}
       </div>
 
-      {/* Shared modal */}
+
       {modalCommit && (
         <CommitModal commit={modalCommit} onClose={() => setModalCommit(null)} />
       )}

--- a/ui/features/history/components/HistoryTab.tsx
+++ b/ui/features/history/components/HistoryTab.tsx
@@ -1,0 +1,443 @@
+'use client'
+
+// Copyright 2026 SUPSI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useState } from 'react'
+
+import {
+  type ActionType,
+  type CommitRow,
+  type EntityMockData,
+  type EntityState,
+  type EntityType,
+  HISTORY_MOCK,
+} from '@/features/history/mock/historyMockData'
+
+// ─── Badge ───────────────────────────────────────────────────────────────────
+
+const BADGE: Record<ActionType, { bg: string; color: string }> = {
+  INSERT: { bg: '#E6F9F1', color: '#0F6E56' },
+  UPDATE: { bg: '#E6F1FB', color: '#185FA5' },
+  DELETE: { bg: '#FCEBEB', color: '#A32D2D' },
+}
+
+function ActionBadge({ action }: { action: ActionType }) {
+  const { bg, color } = BADGE[action]
+  return (
+    <span
+      className="inline-flex items-center rounded px-2 py-0.5 text-xs font-semibold tracking-wide"
+      style={{ background: bg, color }}
+    >
+      {action}
+    </span>
+  )
+}
+
+// ─── Shared Modal ─────────────────────────────────────────────────────────────
+
+function CommitModal({
+  commit,
+  onClose,
+}: {
+  commit: CommitRow
+  onClose: () => void
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="w-full max-w-lg overflow-hidden rounded-2xl bg-white shadow-2xl" style={{ fontFamily: 'Arial, sans-serif' }}>
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50 px-6 py-4">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+              Version Detail
+            </p>
+            <p className="mt-0.5 font-mono text-sm font-semibold text-gray-800">
+              {commit.date}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="flex h-8 items-center justify-center rounded px-3 text-[10px] font-bold uppercase tracking-wider text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700"
+            aria-label="Close"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="max-h-[70vh] overflow-y-auto px-6 py-5 space-y-5">
+          {/* Commit details */}
+          <div>
+            <SectionLabel>Commit Details</SectionLabel>
+            <div className="space-y-2 text-sm">
+              <KV label="Author" value={commit.author} />
+              <div className="flex items-center gap-3">
+                <span className="w-28 shrink-0 text-xs text-gray-400">Action</span>
+                <ActionBadge action={commit.action} />
+              </div>
+              <KV label="Message" value={`"${commit.message}"`} />
+            </div>
+          </div>
+
+          <hr className="border-gray-100" />
+
+          {/* Diff */}
+          <div>
+            <SectionLabel>What Changed</SectionLabel>
+            <div className="space-y-3">
+              {commit.diff.map((d, i) => (
+                <div key={i}>
+                  <p className="mb-1 text-xs font-medium text-gray-600">{d.field}</p>
+                  <div className="overflow-hidden rounded-md border border-gray-100 font-mono text-xs">
+                    <div className="flex gap-2 bg-red-50 px-3 py-1.5 text-red-700">
+                      <span className="select-none font-bold">−</span>
+                      <span>{d.previous}</span>
+                    </div>
+                    <div className="flex gap-2 bg-green-50 px-3 py-1.5 text-green-700">
+                      <span className="select-none font-bold">+</span>
+                      <span>{d.next}</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <hr className="border-gray-100" />
+
+          {/* Snapshot */}
+          <div>
+            <SectionLabel>Snapshot at this moment</SectionLabel>
+            <div className="space-y-1.5">
+              {Object.entries(commit.snapshot).map(([k, v]) => (
+                <div key={k} className="flex items-start gap-3 text-sm">
+                  <span className="w-40 shrink-0 text-xs text-gray-400">{k}</span>
+                  <span className="font-medium text-[#007668]">{v}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Entity State Card ────────────────────────────────────────────────────────
+
+function EntityCard({
+  entity,
+  onOpenCommit,
+}: {
+  entity: EntityState
+  onOpenCommit: () => void
+}) {
+  return (
+    <div className="mt-4 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50 px-5 py-3">
+        <span className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+          Entity State
+        </span>
+        <span className="font-mono text-xs text-gray-400">as of query time</span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-8 gap-y-3 px-5 py-4">
+        {Object.entries(entity.fields).map(([k, v]) => (
+          <div key={k} className="flex flex-col gap-0.5">
+            <span className="text-[10px] font-medium uppercase tracking-wider text-gray-400">{k}</span>
+            <span className="break-all text-sm font-medium text-gray-800">{v}</span>
+          </div>
+        ))}
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[10px] font-medium uppercase tracking-wider text-gray-400">validFrom</span>
+          <span className="text-sm font-medium text-gray-800">{entity.validFrom}</span>
+        </div>
+      </div>
+
+      <div className="border-t border-gray-100 bg-gray-50 px-5 py-3">
+        <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+          Linked Commit
+        </p>
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-sm text-gray-600">
+            <span className="text-xs text-gray-400">author </span>
+            {entity.commit.author}
+          </span>
+          <ActionBadge action={entity.commit.action} />
+          <span className="italic text-sm text-gray-600">"{entity.commit.message}"</span>
+          <button
+            onClick={onOpenCommit}
+            className="ml-auto text-xs font-medium text-[#007668] hover:underline"
+          >
+            View detail →
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Commit List Table ────────────────────────────────────────────────────────
+
+function CommitTable({
+  rows,
+  selectedId,
+  onRowClick,
+}: {
+  rows: CommitRow[]
+  selectedId: string | null
+  onRowClick: (r: CommitRow) => void
+}) {
+  return (
+    <div className="mt-4 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-100 bg-gray-50 text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+            <th className="px-4 py-3 text-left">Date</th>
+            <th className="px-4 py-3 text-left">Author</th>
+            <th className="px-4 py-3 text-left">Action</th>
+            <th className="px-4 py-3 text-left">Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.id}
+              onClick={() => onRowClick(row)}
+              className={`cursor-pointer border-b border-gray-50 transition-colors last:border-0 ${
+                row.id === selectedId ? 'bg-[#007668]/10' : 'hover:bg-gray-50'
+              }`}
+            >
+              <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-gray-500">
+                {row.date}
+              </td>
+              <td className="px-4 py-3 text-gray-700">{row.author}</td>
+              <td className="px-4 py-3">
+                <ActionBadge action={row.action} />
+              </td>
+              <td className="px-4 py-3 italic text-gray-600">"{row.message}"</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// ─── Date + Time inputs ───────────────────────────────────────────────────────
+
+function DateTimeInput({
+  label,
+  date,
+  time,
+  onDateChange,
+  onTimeChange,
+}: {
+  label: string
+  date: string
+  time: string
+  onDateChange: (v: string) => void
+  onTimeChange: (v: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+        {label}
+      </span>
+      <div className="flex gap-2">
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => onDateChange(e.target.value)}
+          className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-[#007668] focus:outline-none focus:ring-1 focus:ring-[#007668]"
+        />
+        <input
+          type="time"
+          value={time}
+          onChange={(e) => onTimeChange(e.target.value)}
+          className="w-28 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-[#007668] focus:outline-none focus:ring-1 focus:ring-[#007668]"
+        />
+      </div>
+    </div>
+  )
+}
+
+function SearchButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="mt-auto flex items-center justify-center rounded-lg bg-[#007668] px-5 py-2 text-sm font-semibold text-white shadow-sm transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-[#007668] focus:ring-offset-2"
+    >
+      Search
+    </button>
+  )
+}
+
+// ─── Tiny shared helpers ──────────────────────────────────────────────────────
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-3 text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+      {children}
+    </p>
+  )
+}
+
+function KV({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="w-28 shrink-0 text-xs text-gray-400">{label}</span>
+      <span className="text-gray-800">{value}</span>
+    </div>
+  )
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+type QueryMode = 'single' | 'range'
+
+interface HistoryTabProps {
+  /** Which SensorThings entity this tab is for */
+  entityType: EntityType
+}
+
+export default function HistoryTab({ entityType }: HistoryTabProps) {
+  const mock: EntityMockData = HISTORY_MOCK[entityType]
+
+  const [mode, setMode] = useState<QueryMode>('single')
+
+  // Single-point
+  const [spDate, setSpDate] = useState(mock.defaultAsOf.date)
+  const [spTime, setSpTime] = useState(mock.defaultAsOf.time)
+  const [entityResult, setEntityResult] = useState<EntityState | null>(null)
+
+  // Range
+  const [fromDate, setFromDate] = useState(mock.defaultRange.fromDate)
+  const [fromTime, setFromTime] = useState(mock.defaultRange.fromTime)
+  const [toDate, setToDate]     = useState(mock.defaultRange.toDate)
+  const [toTime, setToTime]     = useState(mock.defaultRange.toTime)
+  const [commits, setCommits]   = useState<CommitRow[]>([])
+
+  // Modal
+  const [modalCommit, setModalCommit] = useState<CommitRow | null>(null)
+  const [selectedId, setSelectedId]   = useState<string | null>(null)
+
+  // Reset when entity changes
+  function resetState() {
+    setEntityResult(null)
+    setCommits([])
+    setModalCommit(null)
+    setSelectedId(null)
+  }
+
+  const MODES: { key: QueryMode; label: string }[] = [
+    { key: 'single', label: 'Single Point' },
+    { key: 'range',  label: 'Range' },
+  ]
+
+  return (
+    <>
+      <div className="rounded-xl border border-gray-200 bg-white shadow-sm" style={{ fontFamily: 'Arial, sans-serif' }}>
+        {/* Mode toggle */}
+        <div className="flex border-b border-gray-100">
+          {MODES.map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() => { setMode(key); resetState() }}
+              className={`relative px-5 py-3 text-sm font-medium transition-colors focus:outline-none ${
+                mode === key ? 'text-[#007668]' : 'text-gray-400 hover:text-gray-600'
+              }`}
+            >
+              {label}
+              {mode === key && (
+                <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[#007668]" />
+              )}
+            </button>
+          ))}
+        </div>
+
+        {/* ── Single Point ── */}
+        {mode === 'single' && (
+          <div className="p-5">
+            <SectionLabel>as_of</SectionLabel>
+            <div className="flex flex-wrap items-end gap-3">
+              <DateTimeInput
+                label="Date & Time"
+                date={spDate}
+                time={spTime}
+                onDateChange={setSpDate}
+                onTimeChange={setSpTime}
+              />
+              <SearchButton onClick={() => setEntityResult(mock.asOf)} />
+            </div>
+
+            {entityResult && (
+              <EntityCard
+                entity={entityResult}
+                onOpenCommit={() => {
+                  setModalCommit(mock.fromTo[0])
+                  setSelectedId(mock.fromTo[0].id)
+                }}
+              />
+            )}
+          </div>
+        )}
+
+        {/* ── Range ── */}
+        {mode === 'range' && (
+          <div className="p-5">
+            <SectionLabel>from_to</SectionLabel>
+            <div className="flex flex-wrap items-end gap-4">
+              <DateTimeInput
+                label="From"
+                date={fromDate}
+                time={fromTime}
+                onDateChange={setFromDate}
+                onTimeChange={setFromTime}
+              />
+              <div className="pb-1 self-center text-lg font-light text-gray-300">→</div>
+              <DateTimeInput
+                label="To"
+                date={toDate}
+                time={toTime}
+                onDateChange={setToDate}
+                onTimeChange={setToTime}
+              />
+              <SearchButton onClick={() => { setCommits(mock.fromTo); setSelectedId(null) }} />
+            </div>
+
+            {commits.length > 0 && (
+              <CommitTable
+                rows={commits}
+                selectedId={selectedId}
+                onRowClick={(row) => { setSelectedId(row.id); setModalCommit(row) }}
+              />
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Shared modal */}
+      {modalCommit && (
+        <CommitModal commit={modalCommit} onClose={() => setModalCommit(null)} />
+      )}
+    </>
+  )
+}
+

--- a/ui/features/history/components/TravelTimeShared.tsx
+++ b/ui/features/history/components/TravelTimeShared.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import { ActionType } from './travelTimeTypes'
+
+const BADGE: Record<ActionType, { bg: string; color: string }> = {
+  INSERT: { bg: '#E6F9F1', color: '#0F6E56' },
+  UPDATE: { bg: '#E6F1FB', color: '#185FA5' },
+  DELETE: { bg: '#FCEBEB', color: '#A32D2D' },
+}
+
+export function ActionBadge({ action }: { action: ActionType }) {
+  const { bg, color } = BADGE[action]
+  return (
+    <span
+      className="inline-flex items-center rounded px-2 py-0.5 text-xs font-semibold tracking-wide"
+      style={{ background: bg, color }}
+    >
+      {action}
+    </span>
+  )
+}
+
+export function SectionLabel({ children }: { children: React.ReactNode }) {
+  return <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-gray-400">{children}</p>
+}
+
+export function DateTimeInput({
+  label,
+  date,
+  time,
+  onDateChange,
+  onTimeChange,
+}: {
+  label: string
+  date: string
+  time: string
+  onDateChange: (v: string) => void
+  onTimeChange: (v: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] font-semibold uppercase tracking-widest text-gray-400">{label}</span>
+      <div className="flex gap-2">
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => onDateChange(e.target.value)}
+          className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-[#007668] focus:outline-none focus:ring-1 focus:ring-[#007668]"
+        />
+        <input
+          type="time"
+          value={time}
+          onChange={(e) => onTimeChange(e.target.value)}
+          className="w-28 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-[#007668] focus:outline-none focus:ring-1 focus:ring-[#007668]"
+        />
+      </div>
+    </div>
+  )
+}
+
+export function SearchBtn({ onClick, label = 'Search' }: { onClick: () => void; label?: string }) {
+  return (
+    <button
+      onClick={onClick}
+      className="mt-auto flex items-center justify-center rounded-lg bg-[#007668] px-5 py-2 text-sm font-semibold text-white shadow-sm transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-[#007668] focus:ring-offset-2"
+    >
+      {label}
+    </button>
+  )
+}
+
+export function KV({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="w-28 shrink-0 text-xs text-gray-400">{label}</span>
+      <span className="text-gray-800">{value}</span>
+    </div>
+  )
+}

--- a/ui/features/history/components/TravelTimeUI.tsx
+++ b/ui/features/history/components/TravelTimeUI.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import React, { useState } from 'react'
+import { EntityType, GenericEntity, ENTITY_TYPES, QueryMode, CommitRow } from './travelTimeTypes'
+import { DateTimeInput, SearchBtn, ActionBadge } from './TravelTimeShared'
+import { TABLE_COLUMNS, MOCK_COLLECTIONS, MOCK_COMMITS } from './travelTimeMockData'
+import { EntityDetailScreen } from './EntityDetailScreen'
+import { CommitModal } from './CommitModal'
+
+export default function TravelTimeUI() {
+  const [queryMode, setQueryMode] = useState<QueryMode>('current')
+  const [entityType, setEntityType] = useState<EntityType>('Sensors')
+  const [date, setDate] = useState('2025-12-15')
+  const [time, setTime] = useState('00:00')
+  const [appliedDate, setAppliedDate] = useState<string | null>(null)
+  const [appliedMode, setAppliedMode] = useState<QueryMode>('current')
+  const [selectedEntity, setSelectedEntity] = useState<GenericEntity | null>(null)
+  const [modal, setModal] = useState<CommitRow | null>(null)
+
+  if (selectedEntity) {
+    return (
+      <EntityDetailScreen
+        entityType={entityType}
+        entity={selectedEntity}
+        onBack={() => setSelectedEntity(null)}
+      />
+    )
+  }
+
+  const columns = TABLE_COLUMNS[entityType]
+  const entityCommits = MOCK_COMMITS[entityType] || []
+
+  const handleSearch = () => {
+    setAppliedDate(date)
+    setAppliedMode(queryMode)
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6 pb-20" style={{ fontFamily: 'Arial, sans-serif' }}>
+      <div className="mx-auto max-w-5xl">
+        <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-800 tracking-tight">History Explorer</h1>
+            <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mt-1">Audit and travel through SensorThings entities</p>
+          </div>
+          <div className="flex overflow-hidden rounded-xl border border-gray-200 bg-white p-1 shadow-sm">
+            {(['current', 'as_of', 'from_to'] as const).map((m) => (
+              <button
+                key={m}
+                onClick={() => {
+                  setQueryMode(m)
+                  if (m === 'current') {
+                    setAppliedDate(null)
+                    setAppliedMode('current')
+                  }
+                }}
+                className={`rounded-lg px-4 py-1.5 text-xs font-bold uppercase tracking-wider transition-all ${
+                  queryMode === m ? 'bg-[#007668] text-white shadow-sm' : 'text-gray-400 hover:text-gray-600'
+                }`}
+              >
+                {m === 'from_to' ? 'Versions (Range)' : m.replace('_', ' ')}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Horizontal Entity Tabs */}
+        <div className="mb-6 flex gap-1 border-b border-gray-200 overflow-x-auto no-scrollbar">
+          {ENTITY_TYPES.map((e) => (
+            <button
+              key={e}
+              onClick={() => setEntityType(e)}
+              className={`relative pb-3 text-[10px] font-bold uppercase tracking-widest transition-all ${
+                entityType === e ? 'text-[#007668]' : 'text-gray-400 hover:text-gray-600'
+              } ${
+                e === 'ObservedProperties' || e === 'FeaturesOfInterest' || e === 'HistoricalLocations' ? 'px-8 min-w-[180px]' : 'px-4 min-w-[100px]'
+              }`}
+            >
+              {e}
+              {entityType === e && <div className="absolute inset-x-0 bottom-0 h-0.5 bg-[#007668]" />}
+            </button>
+          ))}
+        </div>
+
+        {/* Query Controls */}
+        <div className="mb-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          {queryMode === 'current' ? (
+             <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-sm font-bold text-gray-800">Live Collection View</h2>
+                  <p className="text-xs text-gray-400">Displaying the most recent state for all {entityType}.</p>
+                </div>
+             </div>
+          ) : queryMode === 'as_of' ? (
+            <div className="flex flex-wrap items-end gap-6">
+              <DateTimeInput label="Query point (As Of)" date={date} time={time} onDateChange={setDate} onTimeChange={setTime} />
+              <SearchBtn onClick={handleSearch} label="Apply Time Filter" />
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-end gap-6">
+              <DateTimeInput label="From" date="2025-10-01" time="00:00" onDateChange={()=>{}} onTimeChange={()=>{}} />
+              <div className="pb-1 text-gray-300">→</div>
+              <DateTimeInput label="To" date="2026-03-22" time="23:00" onDateChange={()=>{}} onTimeChange={()=>{}} />
+              <SearchBtn onClick={handleSearch} label="Search Versions" />
+            </div>
+          )}
+        </div>
+
+        {/* Unified Table Results */}
+        <div className="overflow-x-auto rounded-2xl border border-gray-200 bg-white shadow-sm">
+          <div className="border-b border-gray-100 bg-gray-50/50 px-6 py-3 flex justify-between items-center">
+            <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">
+               {appliedMode === 'from_to' ? 'Full Historical Timeline' : 'Collection Snapshot'}
+            </span>
+          </div>
+
+          <table className="w-full min-w-max text-left text-sm">
+            <thead>
+              {appliedMode === 'from_to' ? (
+                 <tr className="border-b bg-gray-50/20 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                  <th className="px-6 py-4">Timestamp</th>
+                  <th className="px-6 py-4">Entity Name</th>
+                  <th className="px-6 py-4">Action</th>
+                  <th className="px-6 py-4">Properties</th>
+                  <th className="px-6 py-4">Commit Message</th>
+                </tr>
+              ) : (
+                <tr className="border-b bg-gray-50/20 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                  {columns.map((c) => <th key={c.key} className="px-6 py-4">{c.label}</th>)}
+                  {appliedMode === 'as_of' && <th className="px-6 py-4">Status</th>}
+                </tr>
+              )}
+            </thead>
+            <tbody>
+              {appliedMode === 'from_to' ? (
+                entityCommits.map((c) => (
+                  <tr 
+                    key={c.id} 
+                    onClick={() => setModal(c)}
+                    className="group cursor-pointer border-b last:border-0 hover:bg-[#007668]/5"
+                  >
+                    <td className="px-6 py-4 font-mono text-xs text-gray-500">{c.date}</td>
+                    <td className="px-6 py-4 font-bold text-gray-800">{c.snapshot.name || c.id}</td>
+                    <td className="px-6 py-4"><ActionBadge action={c.action} /></td>
+                    <td className="px-6 py-4">
+                       <div className="flex flex-wrap gap-1">
+                          {Object.entries(c.snapshot.properties || {}).map(([pk, pv]) => (
+                             <span key={pk} className="bg-gray-100 text-[10px] px-1.5 py-0.5 rounded text-gray-500 border border-gray-200">
+                                {pk}: {String(pv)}
+                             </span>
+                          ))}
+                       </div>
+                    </td>
+                    <td className="px-6 py-4 italic text-gray-600">"{c.message}"</td>
+                  </tr>
+                ))
+              ) : (
+                MOCK_COLLECTIONS[entityType].map((r) => {
+                  const isDeleted = r.name === 'PM2.5 Sensor' && appliedMode === 'as_of' && appliedDate && appliedDate >= '2026-01-10'
+                  return (
+                    <tr 
+                      key={r.id}
+                      onClick={() => setSelectedEntity(r)}
+                      className="group cursor-pointer border-b last:border-0 hover:bg-[#007668]/5"
+                    >
+                      {columns.map((c) => (
+                        <td key={c.key} className={`px-6 py-4 font-bold ${isDeleted ? 'text-gray-300 line-through' : 'text-gray-700'}`}>
+                          {c.key === 'properties' ? (
+                             <div className="flex flex-wrap gap-1">
+                                {Object.entries(r.properties || {}).map(([pk, pv]) => (
+                                   <span key={pk} className="bg-gray-100 text-[10px] px-1.5 py-0.5 rounded text-gray-500 border border-gray-200">
+                                      {pk}: {String(pv)}
+                                   </span>
+                                ))}
+                             </div>
+                          ) : (
+                            r[c.key]
+                          )}
+                        </td>
+                      ))}
+                      {appliedMode === 'as_of' && (
+                        <td className="px-6 py-4">
+                          {isDeleted ? (
+                            <span className="bg-red-600 text-white text-[9px] font-bold px-2 py-0.5 rounded uppercase">Deleted</span>
+                          ) : (
+                            <span className="text-gray-300 text-[9px] font-bold uppercase tracking-tighter">Current-Active</span>
+                          )}
+                        </td>
+                      )}
+                    </tr>
+                  )
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      {modal && <CommitModal commit={modal} onClose={() => setModal(null)} />}
+    </div>
+  )
+}

--- a/ui/features/history/components/TravelTimeUI.tsx
+++ b/ui/features/history/components/TravelTimeUI.tsx
@@ -64,7 +64,7 @@ export default function TravelTimeUI() {
           </div>
         </div>
 
-        {/* Horizontal Entity Tabs */}
+
         <div className="mb-6 flex gap-1 border-b border-gray-200 overflow-x-auto no-scrollbar">
           {ENTITY_TYPES.map((e) => (
             <button
@@ -82,7 +82,7 @@ export default function TravelTimeUI() {
           ))}
         </div>
 
-        {/* Query Controls */}
+
         <div className="mb-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
           {queryMode === 'current' ? (
              <div className="flex items-center justify-between">
@@ -106,7 +106,7 @@ export default function TravelTimeUI() {
           )}
         </div>
 
-        {/* Unified Table Results */}
+
         <div className="overflow-x-auto rounded-2xl border border-gray-200 bg-white shadow-sm">
           <div className="border-b border-gray-100 bg-gray-50/50 px-6 py-3 flex justify-between items-center">
             <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">

--- a/ui/features/history/components/travelTimeMockData.ts
+++ b/ui/features/history/components/travelTimeMockData.ts
@@ -1,0 +1,95 @@
+import { EntityType, CommitRow, GenericEntity, BarEntry, Period } from './travelTimeTypes'
+
+export const MOCK_COMMITS: Record<EntityType, CommitRow[]> = {
+  Things: [
+    { id: 'th1', date: 'Mar 20, 2026 · 08:00', isoDate: '2026-03-20T08:00', author: 'system-sync', action: 'INSERT', message: 'auto-registration', diff: [{ field: 'name', previous: '—', next: 'IST-AQM-01' }], snapshot: { name: 'IST-AQM-01', description: 'station:ref:001', properties: { hw_rev: '2.1', vendor: 'SUPSI' } } },
+  ],
+  Locations: [
+    { id: 'lo1', date: 'Mar 20, 2026 · 07:30', isoDate: '2026-03-20T07:30', author: 'system-sync', action: 'INSERT', message: 'Location mapping', diff: [{ field: 'location', previous: '—', next: '{"type":"Point","coordinates":[8.956,46.005]}' }], snapshot: { name: 'Lugano-Campus', location: '{"type":"Point","coordinates":[8.956,46.005]}', properties: { srs: 'EPSG:4326' } } },
+  ],
+  Sensors: [
+    { id: 'se1', date: 'Mar 15, 2026 · 08:00', isoDate: '2026-03-15T08:00', author: 'admin-sts', action: 'INSERT', message: 'setup:sensor:pm25', diff: [{ field: 'name', previous: '—', next: 'SENS-PM25-X1' }], snapshot: { name: 'SENS-PM25-X1', metadata: 'http://istsos.org/def/sensor/pm25', description: 'optical-sensor-v2', properties: { calib: '2026-01-10' } } },
+    { id: 'se2', date: 'Mar 21, 2026 · 14:30', isoDate: '2026-03-21T14:30', author: 'tech-ref', action: 'UPDATE', message: 'meta:update:v2.1', diff: [{ field: 'metadata', previous: 'v2.0.pdf', next: 'v2.1.pdf' }], snapshot: { name: 'SENS-PM25-X1', metadata: 'v2.1.pdf', properties: { calib: '2026-01-10' } } },
+  ],
+  Datastreams: [
+    { id: 'ds1', date: 'Mar 18, 2026 · 00:00', isoDate: '2026-03-18T00:00', author: 'system-sync', action: 'INSERT', message: 'stream:init', diff: [{ field: 'unitOfMeasurement', previous: '—', next: '{"name":"PM2.5","symbol":"ug/m3"}' }], snapshot: { name: 'STS-DAT-001', unitOfMeasurement: '{"name":"PM2.5","symbol":"ug/m3"}', properties: { sampling: '300s' } } },
+  ],
+  ObservedProperties: [
+    { id: 'op1', date: 'Mar 10, 2026 · 09:00', isoDate: '2026-03-10T09:00', author: 'admin-sts', action: 'INSERT', message: 'prop:reg:pm25', diff: [{ field: 'name', previous: '—', next: 'PM2.5' }], snapshot: { name: 'PM2.5', definition: 'urn:ogc:def:phenomenon:pm25', properties: { domain: 'air_quality' } } },
+  ],
+  FeaturesOfInterest: [
+    { id: 'fo1', date: 'Mar 20, 2026 · 08:10', isoDate: '2026-03-20T08:10', author: 'system-sync', action: 'INSERT', message: 'foi:mapping', diff: [{ field: 'feature', previous: '—', next: '{"type":"Point","coordinates":[8.956,46.005]}' }], snapshot: { name: 'FOI-AQM-01', feature: '{"type":"Point","coordinates":[8.956,46.005]}', properties: { type: 'SamplingPoint' } } },
+  ],
+  HistoricalLocations: [
+    { id: 'hl1', date: 'Mar 20, 2026 · 07:30', isoDate: '2026-03-20T07:30', author: 'system-sync', action: 'INSERT', message: 'historical:loc:init', diff: [{ field: 'time', previous: '—', next: '2026-03-20T07:30Z' }], snapshot: { time: '2026-03-20T07:30Z', thing_id: '1', commit_id: 'c4' } },
+  ],
+}
+
+export const MOCK_COLLECTIONS: Record<EntityType, GenericEntity[]> = {
+  Things: [
+    { id: 1, name: 'IST-AQM-01', description: 'station:ref:001', properties: { vendor: 'SUPSI', model: 'IST-X1' }, commit_id: 'c1', systemTimeValidity: '2026-03-20' },
+    { id: 2, name: 'IST-AQM-02', description: 'station:ref:002', properties: { deployment: 'internal' }, commit_id: 'c2', systemTimeValidity: '2026-03-21' },
+  ],
+  Locations: [
+    { id: 1, name: 'Lugano-Campus', description: 'Main laboratory office', encodingType: 'application/vnd.geo+json', location: '{"type":"Point","coordinates":[8.956,46.005]}', properties: { srs: 'EPSG:4326' }, commit_id: 'c3', systemTimeValidity: '2026-03-20' },
+  ],
+  HistoricalLocations: [
+    { id: 1, time: '2026-03-20T08:00Z', thing_id: '1', commit_id: 'c4', systemTimeValidity: '2026-03-20' },
+  ],
+  Sensors: [
+    { id: 1, name: 'SENS-TEMP-01', description: 'thermistor-r1', encodingType: 'application/pdf', metadata: 'http://istsos.org/def/sensor/temp', properties: { precision: '0.1' }, commit_id: 'c5' },
+  ],
+  Datastreams: [
+    { id: 1, name: 'STS-DAT-001', description: 'PM2.5 primary stream', unitOfMeasurement: '{"name":"PM2.5","symbol":"ug/m3"}', observationType: 'http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement', fenomenonTime: '2026-03-01/2026-03-20', resultTime: '2026-03-20', properties: { sampling: '300s' }, thing_id: '1', sensor_id: '1', observed_property_id: '1' },
+  ],
+  ObservedProperties: [
+    { id: 1, name: 'PM2.5', definition: 'urn:ogc:def:phenomenon:pm25', description: 'Particulates', properties: { domain: 'air_quality' }, commit_id: 'c6' },
+  ],
+  FeaturesOfInterest: [
+    { id: 1, name: 'FOI-AQM-01', description: 'Sampling point at campus', encodingType: 'application/vnd.geo+json', feature: '{"type":"Point","coordinates":[8.956,46.005]}', properties: { type: 'SamplingPoint' }, commit_id: 'c7' },
+  ],
+}
+
+export const TABLE_COLUMNS: Record<EntityType, { label: string; key: string }[]> = {
+  Things: [
+    { label: 'ID', key: 'id' }, { label: 'Name', key: 'name' }, { label: 'Description', key: 'description' }, { label: 'Properties', key: 'properties' }, { label: 'SystemTime', key: 'systemTimeValidity' },
+  ],
+  Locations: [
+    { label: 'ID', key: 'id' }, { label: 'Name', key: 'name' }, { label: 'Description', key: 'description' }, { label: 'Encoding', key: 'encodingType' }, { label: 'Location', key: 'location' }, { label: 'Properties', key: 'properties' },
+  ],
+  HistoricalLocations: [
+    { label: 'ID', key: 'id' }, { label: 'Time', key: 'time' }, { label: 'Thing', key: 'thing_id' }, { label: 'SystemTime', key: 'systemTimeValidity' },
+  ],
+  Sensors: [
+    { label: 'ID', key: 'id' }, { label: 'Name', key: 'name' }, { label: 'Description', key: 'description' }, { label: 'Encoding', key: 'encodingType' }, { label: 'Metadata', key: 'metadata' },
+  ],
+  Datastreams: [
+    { label: 'ID', key: 'id' }, { label: 'Name', key: 'name' }, { label: 'Description', key: 'description' }, { label: 'Unit', key: 'unitOfMeasurement' }, { label: 'Obs.Type', key: 'observationType' }, { label: 'PhenomenonTime', key: 'phenomenonTime' }, { label: 'Thing', key: 'thing_id' },
+  ],
+  ObservedProperties: [
+    { label: 'ID', key: 'id' }, { label: 'Name', key: 'name' }, { label: 'Definition', key: 'definition' }, { label: 'Description', key: 'description' }, { label: 'Properties', key: 'properties' },
+  ],
+  FeaturesOfInterest: [
+    { label: 'ID', key: 'id' }, { label: 'Name', key: 'name' }, { label: 'Description', key: 'description' }, { label: 'Encoding', key: 'encodingType' }, { label: 'Feature', key: 'feature' },
+  ],
+}
+
+export const CHART_H = 96
+export const PERIOD_BARS: Record<Period, BarEntry[]> = {
+  Day: [
+    { label: '00:00', count: 0 }, { label: '02:00', count: 0 }, { label: '04:00', count: 1 },
+    { label: '06:00', count: 0 }, { label: '08:00', count: 2 }, { label: '10:00', count: 3 },
+    { label: '12:00', count: 1 }, { label: '14:00', count: 0 }, { label: '16:00', count: 2 },
+    { label: '18:00', count: 0 }, { label: '20:00', count: 1 }, { label: '22:00', count: 0 },
+  ],
+  Week: [
+    { label: 'Mon', count: 2 }, { label: 'Tue', count: 5 }, { label: 'Wed', count: 1 },
+    { label: 'Thu', count: 0 }, { label: 'Fri', count: 3 }, { label: 'Sat', count: 0 },
+    { label: 'Sun', count: 1 },
+  ],
+  Month: [
+    { label: 'Mar 01', count: 2 }, { label: 'Mar 04', count: 0 }, { label: 'Mar 07', count: 5 },
+    { label: 'Mar 10', count: 1 }, { label: 'Mar 13', count: 0 }, { label: 'Mar 16', count: 3 },
+    { label: 'Mar 19', count: 2 }, { label: 'Mar 21', count: 4 },
+  ],
+}

--- a/ui/features/history/components/travelTimeTypes.ts
+++ b/ui/features/history/components/travelTimeTypes.ts
@@ -1,0 +1,57 @@
+export type ActionType = 'INSERT' | 'UPDATE' | 'DELETE'
+export type QueryMode = 'current' | 'as_of' | 'from_to'
+export type EntityTab = 'Details' | 'Observations' | 'History'
+export type Period = 'Day' | 'Week' | 'Month'
+
+export type EntityType =
+  | 'Things'
+  | 'Locations'
+  | 'Sensors'
+  | 'Datastreams'
+  | 'ObservedProperties'
+  | 'FeaturesOfInterest'
+  | 'HistoricalLocations'
+
+export const ENTITY_TYPES: EntityType[] = [
+  'Things',
+  'Locations',
+  'HistoricalLocations',
+  'Sensors',
+  'Datastreams',
+  'ObservedProperties',
+  'FeaturesOfInterest',
+]
+
+export interface DiffField {
+  field: string
+  previous: string
+  next: string
+}
+
+export interface CommitRow {
+  id: string
+  date: string
+  isoDate: string
+  author: string
+  action: ActionType
+  message: string
+  diff: DiffField[]
+  snapshot: Record<string, any>
+}
+
+export interface EntityState {
+  fields: Record<string, string>
+  validFrom: string
+  commit: CommitRow
+}
+
+export interface GenericEntity {
+  id: string | number
+  name?: string
+  [key: string]: any
+}
+
+export interface BarEntry {
+  label: string
+  count: number
+}

--- a/ui/features/history/mock/historyMockData.ts
+++ b/ui/features/history/mock/historyMockData.ts
@@ -22,7 +22,7 @@ export const ENTITY_TYPES: EntityType[] = [
   'HistoricalLocations',
 ]
 
-// ─── Shared types ────────────────────────────────────────────────────────────
+
 
 export type ActionType = 'INSERT' | 'UPDATE' | 'DELETE'
 
@@ -69,7 +69,7 @@ export interface EntityMockData {
   fromTo: CommitRow[]
 }
 
-// ─── Things ──────────────────────────────────────────────────────────────────
+
 
 const THINGS: EntityMockData = {
   defaultAsOf: { date: '2026-03-20', time: '12:00' },
@@ -99,7 +99,7 @@ const THINGS: EntityMockData = {
   ],
 }
 
-// ─── Locations ───────────────────────────────────────────────────────────────
+
 
 const LOCATIONS: EntityMockData = {
   defaultAsOf: { date: '2026-03-20', time: '00:00' },
@@ -123,7 +123,7 @@ const LOCATIONS: EntityMockData = {
   ],
 }
 
-// ─── Sensors ─────────────────────────────────────────────────────────────────
+
 
 const SENSORS: EntityMockData = {
   defaultAsOf: { date: '2025-12-01', time: '00:00' },
@@ -160,7 +160,7 @@ const SENSORS: EntityMockData = {
   ],
 }
 
-// ─── Datastreams ─────────────────────────────────────────────────────────────
+
 
 const DATASTREAMS: EntityMockData = {
   defaultAsOf: { date: '2026-03-20', time: '00:00' },
@@ -185,7 +185,7 @@ const DATASTREAMS: EntityMockData = {
   ],
 }
 
-// ─── Observations ────────────────────────────────────────────────────────────
+
 
 const OBSERVATIONS: EntityMockData = {
   defaultAsOf: { date: '2026-03-22', time: '09:00' },
@@ -209,7 +209,7 @@ const OBSERVATIONS: EntityMockData = {
   ],
 }
 
-// ─── ObservedProperties ──────────────────────────────────────────────────────
+
 
 const OBSERVED_PROPERTIES: EntityMockData = {
   defaultAsOf: { date: '2026-03-01', time: '00:00' },
@@ -233,7 +233,7 @@ const OBSERVED_PROPERTIES: EntityMockData = {
   ],
 }
 
-// ─── FeaturesOfInterest ──────────────────────────────────────────────────────
+
 
 const FEATURES_OF_INTEREST: EntityMockData = {
   defaultAsOf: { date: '2026-03-20', time: '00:00' },
@@ -257,7 +257,7 @@ const FEATURES_OF_INTEREST: EntityMockData = {
   ],
 }
 
-// ─── HistoricalLocations ─────────────────────────────────────────────────────
+
 
 const HISTORICAL_LOCATIONS: EntityMockData = {
   defaultAsOf: { date: '2026-03-20', time: '08:00' },
@@ -281,7 +281,7 @@ const HISTORICAL_LOCATIONS: EntityMockData = {
   ],
 }
 
-// ─── Aggregated exports ───────────────────────────────────────────────────────
+
 
 export const HISTORY_MOCK: Record<EntityType, EntityMockData> = {
   Things: THINGS,

--- a/ui/features/history/mock/historyMockData.ts
+++ b/ui/features/history/mock/historyMockData.ts
@@ -1,0 +1,302 @@
+// Copyright 2026 SUPSI — History Mock Data
+// Separate from component logic so it can later be replaced with real API calls.
+
+export type EntityType =
+  | 'Things'
+  | 'Locations'
+  | 'Sensors'
+  | 'Datastreams'
+  | 'Observations'
+  | 'ObservedProperties'
+  | 'FeaturesOfInterest'
+  | 'HistoricalLocations'
+
+export const ENTITY_TYPES: EntityType[] = [
+  'Things',
+  'Locations',
+  'Sensors',
+  'Datastreams',
+  'Observations',
+  'ObservedProperties',
+  'FeaturesOfInterest',
+  'HistoricalLocations',
+]
+
+// ─── Shared types ────────────────────────────────────────────────────────────
+
+export type ActionType = 'INSERT' | 'UPDATE' | 'DELETE'
+
+export interface CommitInfo {
+  author: string
+  action: ActionType
+  message: string
+}
+
+export interface EntityState {
+  /** Human-readable field/value pairs shown on the Entity State Card */
+  fields: Record<string, string>
+  validFrom: string
+  commit: CommitInfo
+}
+
+export interface DiffField {
+  field: string
+  previous: string
+  next: string
+}
+
+export interface CommitRow {
+  id: string
+  /** Display date, e.g. "Dec 1, 2025 · 00:00" */
+  date: string
+  /** ISO-ish string used to pre-fill range picker */
+  isoDate: string
+  author: string
+  action: ActionType
+  message: string
+  diff: DiffField[]
+  snapshot: Record<string, any>
+}
+
+export interface EntityMockData {
+  /** Default date/time to pre-fill the "as_of" single-point picker */
+  defaultAsOf: { date: string; time: string }
+  /** Default range to pre-fill the "from_to" range picker */
+  defaultRange: { fromDate: string; fromTime: string; toDate: string; toTime: string }
+  /** Entity state returned by an as_of query */
+  asOf: EntityState
+  /** Commits returned by a from_to query */
+  fromTo: CommitRow[]
+}
+
+// ─── Things ──────────────────────────────────────────────────────────────────
+
+const THINGS: EntityMockData = {
+  defaultAsOf: { date: '2026-03-20', time: '12:00' },
+  defaultRange: { fromDate: '2026-03-01', fromTime: '00:00', toDate: '2026-03-31', toTime: '23:59' },
+  asOf: {
+    fields: {
+      name: 'IST-AQM-01',
+      description: 'station:ref:001',
+      properties: '{"hw_rev":"2.1","vendor":"SUPSI"}',
+    },
+    validFrom: 'Mar 20, 2026',
+    commit: { author: 'system-sync', action: 'INSERT', message: 'auto-registration' },
+  },
+  fromTo: [
+    {
+      id: 'th1', date: 'Mar 20, 2026 · 08:00', isoDate: '2026-03-20T08:00',
+      author: 'system-sync', action: 'INSERT', message: 'auto-registration',
+      diff: [{ field: 'name', previous: '—', next: 'IST-AQM-01' }],
+      snapshot: { name: 'IST-AQM-01', description: 'station:ref:001', properties: { hw_rev: '2.1', vendor: 'SUPSI' } },
+    },
+    {
+      id: 'th2', date: 'Mar 21, 2026 · 14:20', isoDate: '2026-03-21T14:20',
+      author: 'sts-admin', action: 'UPDATE', message: 'updated hardware property',
+      diff: [{ field: 'properties', previous: '{"hw_rev":"2.0"}', next: '{"hw_rev":"2.1","vendor":"SUPSI"}' }],
+      snapshot: { name: 'IST-AQM-01', description: 'station:ref:001', properties: { hw_rev: '2.1', vendor: 'SUPSI' } },
+    },
+  ],
+}
+
+// ─── Locations ───────────────────────────────────────────────────────────────
+
+const LOCATIONS: EntityMockData = {
+  defaultAsOf: { date: '2026-03-20', time: '00:00' },
+  defaultRange: { fromDate: '2026-03-01', fromTime: '00:00', toDate: '2026-03-31', toTime: '23:59' },
+  asOf: {
+    fields: {
+      name: 'Lugano-Campus',
+      description: 'Main campus installation',
+      location: '{"type":"Point","coordinates":[8.956,46.005]}',
+    },
+    validFrom: 'Mar 20, 2026',
+    commit: { author: 'system-sync', action: 'INSERT', message: 'location' },
+  },
+  fromTo: [
+    {
+      id: 'lo1', date: 'Mar 20, 2026 · 07:30', isoDate: '2026-03-20T07:30',
+      author: 'system-sync', action: 'INSERT', message: 'location',
+      diff: [{ field: 'location', previous: '—', next: '{"type":"Point","coordinates":[8.956,46.005]}' }],
+      snapshot: { name: 'Lugano-Campus', location: '{"type":"Point","coordinates":[8.956,46.005]}', properties: { srs: 'EPSG:4326' } },
+    },
+  ],
+}
+
+// ─── Sensors ─────────────────────────────────────────────────────────────────
+
+const SENSORS: EntityMockData = {
+  defaultAsOf: { date: '2025-12-01', time: '00:00' },
+  defaultRange: { fromDate: '2025-10-01', fromTime: '00:00', toDate: '2026-03-21', toTime: '23:59' },
+  asOf: {
+    fields: {
+      name: 'PMS7003 Dust Sensor',
+      description: 'Laser particle counter for PM2.5 / PM10',
+      encodingType: 'application/pdf',
+      metadata: 'https://cdn.plantower.com/PMS7003.pdf',
+    },
+    validFrom: 'Oct 15, 2025',
+    commit: { author: 'admin', action: 'INSERT', message: 'sensor spec added' },
+  },
+  fromTo: [
+    {
+      id: 'se1', date: 'Oct 15, 2025 · 08:05', isoDate: '2025-10-15T08:05',
+      author: 'admin', action: 'INSERT', message: 'sensor spec added',
+      diff: [{ field: 'name', previous: '—', next: 'PMS7003 Dust Sensor' }],
+      snapshot: { name: 'PMS7003 Dust Sensor', encodingType: 'application/pdf', metadata: 'https://cdn.plantower.com/PMS7003.pdf', properties: { frequency: '5min' } },
+    },
+    {
+      id: 'se2', date: 'Feb 1, 2026 · 10:00', isoDate: '2026-02-01T10:00',
+      author: 'technician', action: 'UPDATE', message: 'updated metadata URL',
+      diff: [{ field: 'metadata', previous: 'https://old-url.com/spec.pdf', next: 'https://cdn.plantower.com/PMS7003.pdf' }],
+      snapshot: { name: 'PMS7003 Dust Sensor', encodingType: 'application/pdf', metadata: 'https://cdn.plantower.com/PMS7003.pdf', properties: { frequency: '5min' } },
+    },
+    {
+      id: 'se3', date: 'Mar 5, 2026 · 16:30', isoDate: '2026-03-05T16:30',
+      author: 'admin', action: 'UPDATE', message: 'added description',
+      diff: [{ field: 'description', previous: '—', next: 'Laser particle counter for PM2.5 / PM10' }],
+      snapshot: { name: 'PMS7003 Dust Sensor', description: 'Laser particle counter for PM2.5 / PM10', encodingType: 'application/pdf', metadata: 'https://cdn.plantower.com/PMS7003.pdf', properties: { frequency: '5min' } },
+    },
+  ],
+}
+
+// ─── Datastreams ─────────────────────────────────────────────────────────────
+
+const DATASTREAMS: EntityMockData = {
+  defaultAsOf: { date: '2026-03-20', time: '00:00' },
+  defaultRange: { fromDate: '2026-03-01', fromTime: '00:00', toDate: '2026-03-31', toTime: '23:59' },
+  asOf: {
+    fields: {
+      name: 'STS-DAT-001',
+      description: 'PM2.5 concentrations',
+      observationType: 'OM_Measurement',
+      unitOfMeasurement: '{"name":"PM2.5","symbol":"ug/m3"}',
+    },
+    validFrom: 'Mar 18, 2026',
+    commit: { author: 'system-sync', action: 'INSERT', message: 'stream:init' },
+  },
+  fromTo: [
+    {
+      id: 'ds1', date: 'Mar 18, 2026 · 00:00', isoDate: '2026-03-18T00:00',
+      author: 'system-sync', action: 'INSERT', message: 'stream:init',
+      diff: [{ field: 'unitOfMeasurement', previous: '—', next: '{"name":"PM2.5","symbol":"ug/m3"}' }],
+      snapshot: { name: 'STS-DAT-001', unitOfMeasurement: '{"name":"PM2.5","symbol":"ug/m3"}', properties: { sampling: '300s' } },
+    },
+  ],
+}
+
+// ─── Observations ────────────────────────────────────────────────────────────
+
+const OBSERVATIONS: EntityMockData = {
+  defaultAsOf: { date: '2026-03-22', time: '09:00' },
+  defaultRange: { fromDate: '2026-03-01', fromTime: '00:00', toDate: '2026-03-31', toTime: '23:59' },
+  asOf: {
+    fields: {
+      result: '42.8',
+      phenomenonTime: '2026-03-22T09:00:00Z',
+      resultQuality: 'QC_PASSED',
+    },
+    validFrom: 'Mar 22, 2026',
+    commit: { author: 'sensor-agent', action: 'INSERT', message: 'auto-ingested reading' },
+  },
+  fromTo: [
+    {
+      id: 'ob1', date: 'Mar 22, 2026 · 09:00', isoDate: '2026-03-22T09:00',
+      author: 'sts-ingest', action: 'INSERT', message: 'auto-ingested reading',
+      diff: [{ field: 'result', previous: '—', next: '42.8' }],
+      snapshot: { result: '42.8', phenomenonTime: '2026-03-22T09:00:00Z', resultQuality: 'QC_PASSED' },
+    },
+  ],
+}
+
+// ─── ObservedProperties ──────────────────────────────────────────────────────
+
+const OBSERVED_PROPERTIES: EntityMockData = {
+  defaultAsOf: { date: '2026-03-01', time: '00:00' },
+  defaultRange: { fromDate: '2026-03-01', fromTime: '00:00', toDate: '2026-03-31', toTime: '23:59' },
+  asOf: {
+    fields: {
+      name: 'PM2.5',
+      definition: 'urn:ogc:def:phenomenon:pm25',
+      description: 'Particulate matter ≤ 2.5 µm',
+    },
+    validFrom: 'Mar 10, 2026',
+    commit: { author: 'sts-admin', action: 'INSERT', message: 'prop:reg:pm25' },
+  },
+  fromTo: [
+    {
+      id: 'op1', date: 'Mar 10, 2026 · 09:00', isoDate: '2026-03-10T09:00',
+      author: 'sts-admin', action: 'INSERT', message: 'prop:reg:pm25',
+      diff: [{ field: 'name', previous: '—', next: 'PM2.5' }],
+      snapshot: { name: 'PM2.5', definition: 'urn:ogc:def:phenomenon:pm25' },
+    },
+  ],
+}
+
+// ─── FeaturesOfInterest ──────────────────────────────────────────────────────
+
+const FEATURES_OF_INTEREST: EntityMockData = {
+  defaultAsOf: { date: '2026-03-20', time: '00:00' },
+  defaultRange: { fromDate: '2026-03-01', fromTime: '00:00', toDate: '2026-03-31', toTime: '23:59' },
+  asOf: {
+    fields: {
+      name: 'FOI-AQM-01',
+      description: 'Sampling point at Lugano campus',
+      feature: '{"type":"Point","coordinates":[8.956,46.005]}',
+    },
+    validFrom: 'Mar 20, 2026',
+    commit: { author: 'system-sync', action: 'INSERT', message: 'foi:mapping' },
+  },
+  fromTo: [
+    {
+      id: 'fo1', date: 'Mar 20, 2026 · 08:10', isoDate: '2026-03-20T08:10',
+      author: 'system-sync', action: 'INSERT', message: 'foi:mapping',
+      diff: [{ field: 'feature', previous: '—', next: '{"type":"Point","coordinates":[8.956,46.005]}' }],
+      snapshot: { name: 'FOI-AQM-01', feature: '{"type":"Point","coordinates":[8.956,46.005]}' },
+    },
+  ],
+}
+
+// ─── HistoricalLocations ─────────────────────────────────────────────────────
+
+const HISTORICAL_LOCATIONS: EntityMockData = {
+  defaultAsOf: { date: '2026-03-20', time: '08:00' },
+  defaultRange: { fromDate: '2026-03-01', fromTime: '00:00', toDate: '2026-03-31', toTime: '23:59' },
+  asOf: {
+    fields: {
+      time: '2026-03-20T08:00:00Z',
+      thing_id: '1',
+      commit_id: 'c4',
+    },
+    validFrom: 'Mar 20, 2026',
+    commit: { author: 'system-sync', action: 'INSERT', message: 'historical:loc:init' },
+  },
+  fromTo: [
+    {
+      id: 'hl1', date: 'Mar 20, 2026 · 07:30', isoDate: '2026-03-20T07:30',
+      author: 'system-sync', action: 'INSERT', message: 'historical:loc:init',
+      diff: [{ field: 'time', previous: '—', next: '2026-03-20T07:30Z' }],
+      snapshot: { time: '2026-03-20T07:30Z', thing_id: '1', commit_id: 'c4' },
+    },
+  ],
+}
+
+// ─── Aggregated exports ───────────────────────────────────────────────────────
+
+export const HISTORY_MOCK: Record<EntityType, EntityMockData> = {
+  Things: THINGS,
+  Locations: LOCATIONS,
+  Sensors: SENSORS,
+  Datastreams: DATASTREAMS,
+  Observations: OBSERVATIONS,
+  ObservedProperties: OBSERVED_PROPERTIES,
+  FeaturesOfInterest: FEATURES_OF_INTEREST,
+  HistoricalLocations: HISTORICAL_LOCATIONS,
+}
+
+/** All commits across all entities, sorted newest first — used by CommitHistoryTab */
+export const ALL_COMMITS_GLOBAL: (CommitRow & { entity: EntityType })[] = (
+  Object.entries(HISTORY_MOCK) as [EntityType, EntityMockData][]
+).flatMap(([entity, data]) =>
+  data.fromTo.map((c) => ({ ...c, entity }))
+).sort((a, b) => b.isoDate.localeCompare(a.isoDate))


### PR DESCRIPTION
Hello, I have made a small prototype that shows my understanding for Idea 3 implementation
## Features

### 1. New History Page
I created a new page at `/history` where you can see the history of everything in the system. I also added a link to it from the Home page so it's easy to find.

### 2. Time-Travel Querying
You can now check how things looked in the past. There are three modes:

- **Current**: See the state of a group of entities in the current time
- **As-Of**: See the state of a group of entities (like all Sensors) at a specific date and time.  
- **Range (Versions)**: See a list of all changes (commits) that happened between two dates, therefore showing how its meta data changed over time. "It shows currently the commits and the snapshot of each entity at that time, cause the one entity could have multiple versions and multiple snapshots"

### 3. Support for all STA Entities
The explorer works with all the main SensorThings entities:

- Things  
- Sensors  
- Datastreams  
- Locations  
- Observed Properties  
- FOIs  

### 4. Commit History
Each entity has a commit history that shows all changes made to it over time, including the author, action type, commit message, field-level diff between versions, and an activity graph similar to Github's contriubtion view.
## Technical Details

- Added the feature under `ui/features/history/`.  
- Created a new route in `ui/app/history/page.tsx`.  


### Add at the end:
"Note: This prototype uses mock data.
During the process of the development for GSoC the real integration will use
- GET /Entity(id)?$as_of=....&$expand=Commit
- GET /Entity(id)?$from_to=...&$expand=Commit
- GET /Entity(id)/activity?period=week
That's not all Endpoints that will be used
"

