### PR TITLE
fix: add missing i18n keys for ObservationGraph loading states

### DIFF
--- a/ui/locales/en/translation.json
+++ b/ui/locales/en/translation.json
@@ -24,9 +24,11 @@
     "next": "Next",
     "finish": "Finish",
     "no_data": "No data available.",
+    "select_datastream": "Select a datastream to view the chart",
+    "loading": "Loading...",
     "reset": "Reset"
   },
-    "wizard": {
+  "wizard": {
     "title": "Create SensorThings entities",
     "subtitle": "Choose whether to create one entity or build a guided associated setup.",
     "single_mode": "Single entity",

--- a/ui/locales/it/translation.json
+++ b/ui/locales/it/translation.json
@@ -24,9 +24,11 @@
     "next": "Avanti",
     "finish": "Conferma",
     "no_data": "Nessun dato disponibile.",
+    "select_datastream": "Seleziona un datastream per visualizzare il grafico",
+    "loading": "Caricamento...",
     "reset": "Reset"
   },
-    "wizard": {
+  "wizard": {
     "title": "Crea entità SensorThings",
     "subtitle": "Scegli se creare una sola entità o costruire un setup guidato di entità associate.",
     "single_mode": "Entità singola",


### PR DESCRIPTION
`ObservationGraph.tsx` uses `t('general.select_datastream')` and `t('general.loading')` but neither key existed in the locale files, causing the hardcoded English fallback strings to always render regardless of the user's language setting.

Added the missing keys to both `en/translation.json` and `it/translation.json`.