### PR TITLE
Fix ESLint circular config crash in `ui/eslint.config.mjs`

### DIFF
--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -1,25 +1,17 @@
-import { FlatCompat } from '@eslint/eslintrc'
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
+import { defineConfig, globalIgnores } from 'eslint/config'
+import nextTypescript from 'eslint-config-next/typescript'
+import nextVitals from 'eslint-config-next/core-web-vitals'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-})
-
-const eslintConfig = [
-  ...compat.extends('next/core-web-vitals', 'next/typescript'),
-  {
-    ignores: [
-      'node_modules/**',
-      '.next/**',
-      'out/**',
-      'build/**',
-      'next-env.d.ts',
-    ],
-  },
-]
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTypescript,
+  globalIgnores([
+    'node_modules/**',
+    '.next/**',
+    'out/**',
+    'build/**',
+    'next-env.d.ts',
+  ]),
+])
 
 export default eslintConfig


### PR DESCRIPTION
### Proposed Changes
- Replace `FlatCompat` usage.
- Use flat configs directly from:
  - `eslint-config-next/core-web-vitals`
  - `eslint-config-next/typescript`
- Keep ignore patterns unchanged.

 fix #29