### PR TITLE
fix: correct docker-compose filename in setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ npm install
 ### Start the development services:
 
 ```bash
-docker compose -f docker-compose_dev.yml up -d
+docker compose -f dev-docker-compose.yaml up -d
 ```
 
 ### Stop the development services:
 
 ```bash
-docker compose -f docker-compose_dev.yml down
+docker compose -f dev-docker-compose.yaml down
 ```
 
 ## 4. Access the Application


### PR DESCRIPTION
##  OVERVIEW
The setup instructions in the README file currently reference a file named docker-compose_dev.yml. Following this command causes Docker to break because the file does not exist.

This PR updates the setup guide to use the correct file present in the repository root: dev-docker-compose.yaml.

## Changes Made:
* **Changed the start command** to use `dev-docker-compose.yaml`.
* **Changed the stop command** to use `dev-docker-compose.yaml`.

## Verification:
Verified locally on Windows 11 by manually creating the missing network bridge and successfully initializing the development environment container.